### PR TITLE
Add elapsed time tracking and display

### DIFF
--- a/src/components/GameOverlay.tsx
+++ b/src/components/GameOverlay.tsx
@@ -1,14 +1,15 @@
 import { useGame } from '../context/GameContext';
+import { formatTime } from '../utils/formatTime'; 
 
 export const GameOverlay = () => {
-  const { gameStatus, score, level, startGame, resumeGame, restartGame, startRound, nextLevel } = useGame();
+  const { gameStatus, score, level, elapsedTime, startGame, resumeGame, restartGame, startRound, nextLevel } = useGame();
 
   if (gameStatus === 'playing') return null;
 
   return (
     <div className="absolute inset-0 z-50 flex flex-col items-center justify-center bg-black/85 backdrop-blur-sm animate-in fade-in duration-300">
       
-      {/*  IDLE / MAIN MENU  */}
+      {/* IDLE / MAIN MENU  */}
       {gameStatus === 'idle' && (
         <div className="text-center flex flex-col items-center gap-6">
           <div className="space-y-2">
@@ -28,7 +29,7 @@ export const GameOverlay = () => {
         </div>
       )}
 
-      {/*  GET READY SCREEN (Manual Start)  */}
+      {/* GET READY SCREEN  */}
       {gameStatus === 'ready' && (
         <div className="text-center space-y-4 animate-pulse">
             <h2 className="text-6xl md:text-8xl font-black text-yellow-400 drop-shadow-[0_0_20px_rgba(250,204,21,0.8)] tracking-widest">
@@ -45,7 +46,7 @@ export const GameOverlay = () => {
         </div>
       )}
 
-      {/*  PAUSE MENU  */}
+      {/* PAUSE MENU  */}
       {gameStatus === 'paused' && (
         <div className="text-center space-y-8">
           <h2 className="text-5xl font-bold text-blue-400 tracking-[0.2em] drop-shadow-[0_0_10px_blue]">PAUSED</h2>
@@ -66,7 +67,7 @@ export const GameOverlay = () => {
         </div>
       )}
 
-      {/*  VICTORY / NEXT LEVEL MENU  */}
+      {/* VICTORY / NEXT LEVEL MENU  */}
       {gameStatus === 'won' && (
         <div className="text-center space-y-6 animate-in zoom-in duration-500">
           <h1 className="text-6xl md:text-7xl font-black bg-clip-text bg-linear-to-r from-green-400 to-emerald-600 drop-shadow-[0_0_25px_rgba(34,197,94,0.8)] animate-bounce">
@@ -74,8 +75,19 @@ export const GameOverlay = () => {
           </h1>
           
           <div className="bg-white/10 p-8 rounded-2xl border border-green-500/30 backdrop-blur-md shadow-[0_0_30px_rgba(34,197,94,0.2)]">
-            <p className="text-white/70 text-sm uppercase tracking-wider mb-2">Current Score</p>
-            <p className="text-6xl font-black text-yellow-400 drop-shadow-lg">{score}</p>
+            <div className="grid grid-cols-2 gap-8 text-center">
+                <div>
+                    <p className="text-white/70 text-sm uppercase tracking-wider mb-2">Current Score</p>
+                    <p className="text-6xl font-black text-yellow-400 drop-shadow-lg">{score}</p>
+                </div>
+                {/* Time Display */}
+                <div>
+                    <p className="text-white/70 text-sm uppercase tracking-wider mb-2">Time</p>
+                    <p className="text-6xl font-black text-blue-400 font-mono drop-shadow-lg">
+                        {formatTime(elapsedTime)}
+                    </p>
+                </div>
+            </div>
           </div>
 
           <button 
@@ -87,14 +99,25 @@ export const GameOverlay = () => {
         </div>
       )}
 
-      {/*  GAME OVER MENU  */}
+      {/* GAME OVER MENU  */}
       {gameStatus === 'gameover' && (
         <div className="text-center space-y-6">
           <h1 className="text-7xl font-bold text-red-600 drop-shadow-[0_0_25px_red] animate-pulse">GAME OVER</h1>
           
           <div className="bg-white/10 p-6 rounded-2xl border border-white/10 backdrop-blur-md">
-            <p className="text-white/70 text-sm uppercase tracking-wider mb-2">Final Score</p>
-            <p className="text-5xl font-bold text-yellow-400">{score}</p>
+             <div className="flex justify-between items-center gap-12">
+                <div className="text-center">
+                    <p className="text-white/70 text-sm uppercase tracking-wider mb-2">Final Score</p>
+                    <p className="text-5xl font-bold text-yellow-400">{score}</p>
+                </div>
+                {/*  Time Display */}
+                <div className="text-center">
+                    <p className="text-white/70 text-sm uppercase tracking-wider mb-2">Total Time</p>
+                    <p className="text-5xl font-bold text-red-400 font-mono">
+                        {formatTime(elapsedTime)}
+                    </p>
+                </div>
+             </div>
           </div>
 
           <button 

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -13,6 +13,8 @@ export interface GameContextType {
   lives: number; 
   level: number;
   activeBonus: ActiveBonus | null;
+  
+  elapsedTime: number;
 
   movePlayer: (x: number, z: number) => void;
   startGame: () => void; 

--- a/src/context/GameProvider.tsx
+++ b/src/context/GameProvider.tsx
@@ -63,6 +63,8 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
   const [activeBonus, setActiveBonus] = useState<ActiveBonus | null>(null);
   const [extraLifeSpawned, setExtraLifeSpawned] = useState(false);
 
+  const [elapsedTime, setElapsedTime] = useState<number>(0);
+
   //  REFS
   const waveTimerRef = useRef<number>(0);
   const powerModeTimerRef = useRef<number | null>(null);
@@ -75,6 +77,21 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
 
   useEffect(() => { playerPosRef.current = playerPos; }, [playerPos]);
   useEffect(() => { layoutRef.current = layout; }, [layout]);
+
+  // timer logic
+  useEffect(() => {
+    let intervalId: number;
+
+    if (gameStatus === 'playing') {
+      intervalId = window.setInterval(() => {
+        setElapsedTime((prev) => prev + 1);
+      }, 1000);
+    }
+
+    return () => {
+      if (intervalId) clearInterval(intervalId);
+    };
+  }, [gameStatus]);
 
   //SPAWN LOGIC
   const spawnBonus = useCallback((type: BonusType) => {
@@ -148,6 +165,9 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
     setActiveBonus(null);
     setExtraLifeSpawned(false);
     
+    //time reset when restarting game
+    setElapsedTime(0);
+
     setGameStatus('ready'); 
     setGlobalMode('SCATTER');
     setWaveIndex(0);
@@ -262,7 +282,6 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
           if (newDots === 50) spawnBonus('CHERRY');
           if (newDots === 900) spawnBonus('STRAWBERRY');
           
-          // Life Spawn
           if (newDots === 100 && !extraLifeSpawned && lives < MAX_LIVES) {
               spawnBonus('EXTRA_LIFE');
               setExtraLifeSpawned(true);
@@ -434,7 +453,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
 
   return (
     <GameContext.Provider value={{ 
-      playerPos, ghostsPos, score, layout, gameStatus, remainingFood, lives, level, activeBonus,
+      playerPos, ghostsPos, score, layout, gameStatus, remainingFood, lives, level, activeBonus, elapsedTime,
       movePlayer, startGame, startRound, pauseGame, resumeGame, restartGame, nextLevel 
     }}>
       {children}

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -9,10 +9,11 @@ import { cn } from '../utils/cn';
 import { usePlayerHeading } from '../hooks/usePlayerHeading'; 
 import { useIsMobile } from '../hooks/useIsMobile'; 
 import { Link } from 'react-router-dom'; 
+import { formatTime } from '../utils/formatTime'; 
 
 export const GamePage = () => {
   const { settings, updateSetting } = useTheme();
-  const { score, gameStatus, pauseGame, lives, level } = useGame();
+  const { score, gameStatus, pauseGame, lives, level, elapsedTime } = useGame();
   const playerHeading = usePlayerHeading();
   const isMobile = useIsMobile();
   
@@ -118,6 +119,14 @@ export const GamePage = () => {
                         {score}
                     </span>
                 </div>
+           </div>
+
+           {/* Timer Display */}
+           <div className="flex flex-col items-center">
+                <span className="text-[9px] text-gray-500 font-bold uppercase tracking-widest landscape:max-lg:hidden">Time</span>
+                <span className="text-white font-mono font-bold text-lg tabular-nums tracking-wider">
+                    {formatTime(elapsedTime)}
+                </span>
            </div>
 
            {/* Level Indicator */}

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -1,0 +1,5 @@
+export const formatTime = (seconds: number): string => {
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+};


### PR DESCRIPTION
Introduce elapsed time tracking to the game: add elapsedTime state to GameProvider with a running interval while gameStatus is 'playing', clear on cleanup, and reset when restarting a game. Expose elapsedTime in the GameContext type and provider value. Add a small formatTime util and use it to render formatted time in the HUD (GamePage) and overlays (GameOverlay — victory and game over screens). Adjust overlay layouts to include the time display alongside scores.