### PR TITLE
Persist theme; refactor audio and add sliders

### DIFF
--- a/src/components/Game/3D/Ghost3D.tsx
+++ b/src/components/Game/3D/Ghost3D.tsx
@@ -7,8 +7,7 @@ import { useGame } from '../../../context/GameContext';
 import { ClassicGhost } from './Ghosts/ClassicGhost';
 import { ReaperGhost } from './Ghosts/ReaperGhost';
 import { Eyes3D } from './Ghosts/Eyes3D'; 
-import { TileType } from '../../../types'; 
-import type { GhostState } from '../../../types';
+import { TileType, type GhostState } from '../../../types'; 
 
 interface Ghost3DProps {
   x: number;
@@ -20,17 +19,12 @@ interface Ghost3DProps {
 const isWallBetween = (x1: number, z1: number, x2: number, z2: number, layout: number[][]) => {
     const steps = Math.max(Math.abs(x2 - x1), Math.abs(z2 - z1));
     if (steps === 0) return false;
-
     const dx = (x2 - x1) / steps;
     const dz = (z2 - z1) / steps;
-
     for (let i = 1; i < steps; i++) {
         const checkX = Math.round(x1 + dx * i);
         const checkZ = Math.round(z1 + dz * i);
-        
-        if (layout[checkZ] && layout[checkZ][checkX] === TileType.WALL) {
-            return true; 
-        }
+        if (layout[checkZ] && layout[checkZ][checkX] === TileType.WALL) return true; 
     }
     return false; 
 };
@@ -45,24 +39,34 @@ export const Ghost3D = ({ x, z, color, state }: Ghost3DProps) => {
   const prevPos = useRef({ x, z });
   const targetRotation = useRef(0);
 
-  const isSfxEnabled = !settings.audio.masterMuted && settings.audio.sfxVolume > 0;
+  // Audio Calculations
+  const masterMuted = settings.audio.masterMuted;
+  const sfxVolume = settings.audio.sfxVolume;
+  const isSfxEnabled = !masterMuted && sfxVolume > 0;
+  
   const shouldPlaySound = isSfxEnabled && gameStatus === 'playing';
 
   useEffect(() => {
     if (audioRef.current) {
-        audioRef.current.setVolume(settings.audio.sfxVolume * 1.5);
-        
+        if (!isSfxEnabled) {
+            audioRef.current.setVolume(0);
+        }
         if (audioRef.current.setRolloffFactor) {
-            audioRef.current.setRolloffFactor(0);
+            audioRef.current.setRolloffFactor(0); 
         }
     }
-  }, [settings.audio.sfxVolume, isSfxEnabled]);
+  }, [sfxVolume, isSfxEnabled]);
 
   useFrame(() => {
-    if (!audioRef.current || !shouldPlaySound) return;
+    if (!audioRef.current) return;
+    
+    if (!shouldPlaySound) {
+        if (audioRef.current.getVolume() > 0) audioRef.current.setVolume(0);
+        return;
+    }
 
     const distance = Math.hypot(x - playerPos.x, z - playerPos.z);
-    const MAX_AUDIBLE_DISTANCE = 15; 
+    const MAX_AUDIBLE_DISTANCE = 12; 
     
     if (distance > MAX_AUDIBLE_DISTANCE) {
         audioRef.current.setVolume(0);
@@ -72,10 +76,10 @@ export const Ghost3D = ({ x, z, color, state }: Ghost3DProps) => {
     let volume = 1 - (distance / MAX_AUDIBLE_DISTANCE);
     
     if (isWallBetween(playerPos.x, playerPos.z, x, z, layout)) {
-        volume *= 0.2; 
+        volume *= 0.2;
     }
 
-    audioRef.current.setVolume(volume * settings.audio.sfxVolume * 1.5);
+    audioRef.current.setVolume(volume * sfxVolume * 1.5);
   });
 
   useEffect(() => {
@@ -93,7 +97,6 @@ export const Ghost3D = ({ x, z, color, state }: Ghost3DProps) => {
     const targetPos = new Vector3(x, 0.5, z);
     const speed = state === 'EATEN' ? 15.0 : 6.0; 
     currentPos.lerp(targetPos, speed * delta);
-
     const tRotation = targetRotation.current;
     const cRotation = groupRef.current.rotation.y;
     let diff = tRotation - cRotation;
@@ -122,7 +125,8 @@ export const Ghost3D = ({ x, z, color, state }: Ghost3DProps) => {
            </>
         )}
       </group>
-      {shouldPlaySound && state !== 'EATEN' && state !== 'EYES' && (
+      
+      {state !== 'EATEN' && state !== 'EYES' && (
         <PositionalAudio
           ref={audioRef}
           url="/sounds/siren.mp3" 

--- a/src/components/Game/Foods/Food3D.tsx
+++ b/src/components/Game/Foods/Food3D.tsx
@@ -32,14 +32,19 @@ export const Food3D = ({ consumableVariant }: Food3DProps) => {
   const { settings } = useTheme();
   
   const themeDerivedPelletColor = settings?.foodColor ?? '#fef08a';
-  const isSfxEnabled = !settings.audio.masterMuted && settings.audio.sfxVolume > 0;
+  
+  // Audio Logic
+  const masterMuted = settings.audio.masterMuted;
+  const sfxVolume = settings.audio.sfxVolume;
+  const isSfxEnabled = !masterMuted && sfxVolume > 0;
   const isBonus = ['cherry', 'strawberry', 'life'].includes(consumableVariant);
 
   useEffect(() => {
     if (audioRef.current) {
-        audioRef.current.setVolume(settings.audio.sfxVolume * 0.8);
+        const targetVol = isSfxEnabled ? sfxVolume * 0.8 : 0;
+        audioRef.current.setVolume(targetVol);
     }
-  }, [settings.audio.sfxVolume, isSfxEnabled]);
+  }, [sfxVolume, isSfxEnabled]);
 
   useFrame((state) => {
     if (!meshGroupRef.current) return;
@@ -53,17 +58,17 @@ export const Food3D = ({ consumableVariant }: Food3DProps) => {
   });
 
   const heartGeometry = useMemo(() => {
-    const x = 0, y = 0;
-    const heartShape = new Shape();
-    heartShape.moveTo( x + 0.25, y + 0.25 );
-    heartShape.bezierCurveTo( x + 0.25, y + 0.25, x + 0.20, y, x, y );
-    heartShape.bezierCurveTo( x - 0.30, y, x - 0.30, y + 0.35, x - 0.30, y + 0.35 );
-    heartShape.bezierCurveTo( x - 0.30, y + 0.55, x - 0.10, y + 0.77, x + 0.25, y + 0.95 );
-    heartShape.bezierCurveTo( x + 0.60, y + 0.77, x + 0.80, y + 0.55, x + 0.80, y + 0.35 );
-    heartShape.bezierCurveTo( x + 0.80, y + 0.35, x + 0.80, y, x + 0.50, y );
-    heartShape.bezierCurveTo( x + 0.35, y, x + 0.25, y + 0.25, x + 0.25, y + 0.25 );
-    const extrudeSettings = { depth: 0.2, bevelEnabled: true, bevelSegments: 2, steps: 2, bevelSize: 0.05, bevelThickness: 0.05 };
-    return new ExtrudeGeometry( heartShape, extrudeSettings );
+      const x = 0, y = 0;
+      const heartShape = new Shape();
+      heartShape.moveTo( x + 0.25, y + 0.25 );
+      heartShape.bezierCurveTo( x + 0.25, y + 0.25, x + 0.20, y, x, y );
+      heartShape.bezierCurveTo( x - 0.30, y, x - 0.30, y + 0.35, x - 0.30, y + 0.35 );
+      heartShape.bezierCurveTo( x - 0.30, y + 0.55, x - 0.10, y + 0.77, x + 0.25, y + 0.95 );
+      heartShape.bezierCurveTo( x + 0.60, y + 0.77, x + 0.80, y + 0.55, x + 0.80, y + 0.35 );
+      heartShape.bezierCurveTo( x + 0.80, y + 0.35, x + 0.80, y, x + 0.50, y );
+      heartShape.bezierCurveTo( x + 0.35, y, x + 0.25, y + 0.25, x + 0.25, y + 0.25 );
+      const extrudeSettings = { depth: 0.2, bevelEnabled: true, bevelSegments: 2, steps: 2, bevelSize: 0.05, bevelThickness: 0.05 };
+      return new ExtrudeGeometry( heartShape, extrudeSettings );
   }, []);
 
   const renderMesh = () => {
@@ -95,7 +100,7 @@ export const Food3D = ({ consumableVariant }: Food3DProps) => {
   return (
     <group ref={meshGroupRef}>
         {renderMesh()}
-        {isSfxEnabled && isBonus && (
+        {isBonus && (
            <PositionalAudio
              ref={audioRef}
              url={soundFile} 

--- a/src/components/UI/SettingsComponents.tsx
+++ b/src/components/UI/SettingsComponents.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 // --- WRAPPER FOR SECTIONS ---
 export const SettingsSection = ({ title, children }: { title: string, children: React.ReactNode }) => (
-    <div className="mb-8">
+    <div className="mb-8 animate-in fade-in slide-in-from-bottom-2 duration-500">
         <h4 className="text-xs font-bold text-text-muted uppercase tracking-widest mb-4 pl-1">{title}</h4>
         {children}
     </div>
@@ -11,17 +11,48 @@ export const SettingsSection = ({ title, children }: { title: string, children: 
 // --- TOGGLE SWITCH ---
 export const ToggleSwitch = ({ label, isOn, onToggle }: { label: string, isOn: boolean, onToggle: () => void }) => (
     <div 
-      className="flex items-center justify-between cursor-pointer group py-3 select-none border-b border-white/5 last:border-0" 
+      className="flex items-center justify-between cursor-pointer group py-3 select-none border-b border-border-color/30 last:border-0" 
       onClick={onToggle}
     >
       <span className="text-base font-medium text-text-main transition-colors">
         {label}
       </span>
       {/* Track */}
-      <div className={`w-12 h-7 rounded-full p-1 transition-colors duration-300 ${isOn ? 'bg-primary' : 'bg-white/10'}`}>
+      <div className={`w-12 h-7 rounded-full p-1 transition-colors duration-300 ${isOn ? 'bg-primary shadow-lg shadow-primary/30' : 'bg-black/10 dark:bg-white/10'}`}>
         {/* Knob */}
         <div className={`w-5 h-5 bg-white rounded-full shadow-md transition-transform duration-300 ${isOn ? 'translate-x-5' : 'translate-x-0'}`} />
       </div>
+    </div>
+);
+// --- RANGE SLIDER ---
+interface RangeSliderProps {
+    label: string;
+    value: number; 
+    onChange: (val: number) => void;
+    disabled?: boolean;
+}
+
+export const RangeSlider = ({ label, value, onChange, disabled = false }: RangeSliderProps) => (
+    <div className={`py-3 border-b border-border-color/30 last:border-0 ${disabled ? 'opacity-50 pointer-events-none' : ''}`}>
+        <div className="flex justify-between mb-3">
+            <span className="text-sm font-medium text-text-main">{label}</span>
+            <span className="text-xs font-mono font-bold text-primary">{Math.round(value * 100)}%</span>
+        </div>
+        <input 
+            type="range" 
+            min="0" 
+            max="1" 
+            step="0.05" 
+            value={value}
+            onChange={(e) => onChange(parseFloat(e.target.value))}
+            style={{ 
+                backgroundSize: `${value * 100}% 100%` 
+            }} 
+            className="w-full h-2 rounded-lg appearance-none cursor-pointer 
+                       bg-black/10 dark:bg-white/10 
+                       accent-primary hover:accent-primary-hover focus:outline-none 
+                       bg-linear-to-r from-primary to-primary bg-no-repeat"
+        />
     </div>
 );
 
@@ -32,7 +63,7 @@ export const DifficultyButton = ({ level, isActive, onClick }: { level: string, 
       className={`py-3 px-4 text-xs sm:text-sm font-bold rounded-xl border-2 transition-all duration-200 uppercase tracking-wide ${
           isActive 
           ? 'bg-primary text-black border-primary shadow-[0_0_15px_rgba(0,212,255,0.4)] scale-105' 
-          : 'bg-transparent text-text-muted border-white/10 hover:border-white/30 hover:text-text-main'
+          : 'bg-transparent text-text-muted border-border-color/30 hover:border-text-muted hover:text-text-main'
       }`}
   >
       {level}
@@ -61,7 +92,7 @@ export const ColorSwatchGroup = ({ label, colors, selectedColor, onSelect }: Col
               className={`w-10 h-10 rounded-full border-2 transition-transform duration-200 outline-none ${
                  isSelected 
                    ? 'border-text-main scale-115 shadow-lg ring-2 ring-primary ring-offset-2 ring-offset-bg-main' 
-                   : 'border-transparent hover:scale-110 hover:border-white/20'
+                   : 'border-transparent hover:scale-110 hover:border-text-muted/50'
               }`}
               style={{ backgroundColor: color }}
               aria-label={`Select color ${color}`}

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -3,7 +3,7 @@ import type { ThemeSettings } from '../types';
 
 export interface ThemeContextType {
   settings: ThemeSettings;
-  updateSetting: (key: keyof ThemeSettings, value: string | boolean | number) => void;
+  updateSetting: <K extends keyof ThemeSettings>(key: K, value: ThemeSettings[K]) => void;
   resetTheme: () => void;
 }
 

--- a/src/context/ThemeProvider.tsx
+++ b/src/context/ThemeProvider.tsx
@@ -2,12 +2,21 @@ import { useState, useEffect, type ReactNode } from 'react';
 import { ThemeContext, defaultSettings } from './ThemeContext';
 import type { ThemeSettings } from '../types';
 
+const STORAGE_KEY = 'pacman_theme_settings_v1';
+
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
-  const [settings, setSettings] = useState<ThemeSettings>(defaultSettings);
+  const [settings, setSettings] = useState<ThemeSettings>(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      return saved ? JSON.parse(saved) : defaultSettings;
+    } catch (e) {
+      console.warn('Failed to parse theme settings:', e);
+      return defaultSettings;
+    }
+  });
 
   useEffect(() => {
     const root = document.documentElement;
-
     root.style.setProperty('--wall-color', settings.wallColor);
     root.style.setProperty('--food-color', settings.foodColor);
     root.style.setProperty('--game-bg', settings.gameBg);
@@ -19,11 +28,23 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
     }
   }, [settings]);
 
-  const updateSetting = (key: keyof ThemeSettings, value: string | boolean | number) => {
-    setSettings((prev) => ({ ...prev, [key]: value }));
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  }, [settings]);
+
+  const updateSetting = <K extends keyof ThemeSettings>(key: K, value: ThemeSettings[K]) => {
+    setSettings((prev) => {
+      if (key === 'audio' && typeof value === 'object') {
+         return { ...prev, audio: { ...prev.audio, ...value } };
+      }
+      return { ...prev, [key]: value };
+    });
   };
 
-  const resetTheme = () => setSettings(defaultSettings);
+  const resetTheme = () => {
+      setSettings(defaultSettings);
+      localStorage.removeItem(STORAGE_KEY);
+  };
 
   return (
     <ThemeContext.Provider value={{ settings, updateSetting, resetTheme }}>

--- a/src/hooks/useGameAudio.ts
+++ b/src/hooks/useGameAudio.ts
@@ -6,62 +6,59 @@ export const useGameAudio = () => {
   const { settings } = useTheme();
   const { masterMuted, sfxVolume, musicVolume } = settings.audio;
 
-  //  Music 
+  const effectiveMusicVol = masterMuted ? 0 : musicVolume;
+  const effectiveSfxVol = masterMuted ? 0 : sfxVolume;
+
   const [playIntroRaw, { stop: stopIntro }] = useSound('/sounds/intro.mp3', { 
-    volume: masterMuted ? 0 : musicVolume 
+    volume: effectiveMusicVol
   });
 
-  // Chomp
-  const [playChomp] = useSound('/sounds/chomp.mp3', { 
-    volume: masterMuted ? 0 : sfxVolume * 0.4, 
-    interrupt: true 
-  });
-  
-  // Death
-  const [playDeath] = useSound('/sounds/death.wav', { 
-    volume: masterMuted ? 0 : sfxVolume * 0.5 
-  });
-  
-  // Eat Ghost
-  const [playEatGhost] = useSound('/sounds/eat_ghost.wav', { 
-    volume: masterMuted ? 0 : sfxVolume * 0.5 
-  });
-  
-  // Extra Life 
-  const [playExtraLife] = useSound('/sounds/extra_life.wav', { 
-    volume: masterMuted ? 0 : sfxVolume * 0.6 
-  });
-
-  // Eat Fruit
-  const [playFruit] = useSound('/sounds/eat_fruit.wav', { 
-    volume: masterMuted ? 0 : sfxVolume * 0.6 
-  });
-  // Level Up 
   const [playLevelUp] = useSound('/sounds/level_up.mp3', { 
-    volume: 0.5, 
+    volume: effectiveMusicVol * 0.8, 
+  });
+
+  const [playChomp] = useSound('/sounds/chomp.mp3', { 
+    volume: effectiveSfxVol * 1, 
+    interrupt: true,
+  });
+  
+  const [playDeath] = useSound('/sounds/death.wav', { 
+    volume: effectiveSfxVol * 0.6 
+  });
+  
+  const [playEatGhost] = useSound('/sounds/eat_ghost.wav', { 
+    volume: effectiveSfxVol * 0.6 
+  });
+  
+  const [playExtraLife] = useSound('/sounds/extra_life.wav', { 
+    volume: effectiveSfxVol * 0.7 
+  });
+
+  const [playFruit] = useSound('/sounds/eat_fruit.wav', { 
+    volume: effectiveSfxVol * 0.6 
   });
 
   const playIntro = useCallback(() => {
-    if (!masterMuted && musicVolume > 0) {
+    if (effectiveMusicVol > 0) {
       stopIntro();
       playIntroRaw();
     }
-  }, [masterMuted, musicVolume, playIntroRaw, stopIntro]);
+  }, [effectiveMusicVol, playIntroRaw, stopIntro]);
 
   useEffect(() => {
-    if (masterMuted || musicVolume === 0) {
+    if (effectiveMusicVol === 0) {
         stopIntro();
     }
-  }, [masterMuted, musicVolume, stopIntro]);
+  }, [effectiveMusicVol, stopIntro]);
 
   return {
     playIntro,
     stopIntro,
-    playChomp: !masterMuted && sfxVolume > 0 ? playChomp : () => {},
-    playDeath: !masterMuted && sfxVolume > 0 ? playDeath : () => {},
-    playEatGhost: !masterMuted && sfxVolume > 0 ? playEatGhost : () => {},
-    playExtraLife: !masterMuted && sfxVolume > 0 ? playExtraLife : () => {},
-    playFruit: !masterMuted && sfxVolume > 0 ? playFruit : () => {},
-    playLevelUp: !masterMuted && musicVolume > 0 ? playLevelUp : () => {}, 
+    playChomp: effectiveSfxVol > 0 ? playChomp : () => {},
+    playDeath: effectiveSfxVol > 0 ? playDeath : () => {},
+    playEatGhost: effectiveSfxVol > 0 ? playEatGhost : () => {},
+    playExtraLife: effectiveSfxVol > 0 ? playExtraLife : () => {},
+    playFruit: effectiveSfxVol > 0 ? playFruit : () => {},
+    playLevelUp: effectiveMusicVol > 0 ? playLevelUp : () => {}, 
   };
 };

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useTheme } from '../context/ThemeContext';
-import { SettingsSection, ToggleSwitch, DifficultyButton, ColorSwatchGroup } from '../components/UI/SettingsComponents';
+import { SettingsSection, ToggleSwitch, RangeSlider, DifficultyButton, ColorSwatchGroup } from '../components/UI/SettingsComponents';
 import type { Difficulty } from '../types';
 
 const THEME_PALETTES = {
@@ -11,6 +11,11 @@ const THEME_PALETTES = {
 
 export const SettingsPage = () => {
   const { settings, updateSetting, resetTheme } = useTheme();
+
+  const updateAudio = (key: string, val: number | boolean) => {
+      const currentAudio = settings.audio || { masterMuted: false, musicVolume: 0.5, sfxVolume: 1.0 };
+      updateSetting('audio', { ...currentAudio, [key]: val });
+  };
 
   // Dark Mode Logic
   useEffect(() => {
@@ -29,20 +34,46 @@ export const SettingsPage = () => {
         
         {/* HEADER SECTION */}
         <div className="flex items-center justify-between mb-10">
-            <h2 className="text-3xl font-black">
+            <h2 className="text-3xl font-black text-text-main">
                 Settings
             </h2>
             <button 
                 onClick={resetTheme}
-                className="text-xs font-bold text-red-400 hover:text-red-300 transition-colors px-4 py-2 rounded-full bg-red-500/10 hover:bg-red-500/20"
+                className="text-xs font-bold text-red-500 hover:text-white border border-red-500/30 hover:bg-red-500 px-4 py-2 rounded-full transition-all uppercase tracking-wider"
             >
                 RESET DEFAULT
             </button>
         </div>
 
-        {/* --- 1. DIFFICULTY --- */}
+        {/* AUDIO CONFIGURATION*/}
+        <SettingsSection title="Audio Configuration">
+             <div className="bg-bg-card rounded-2xl p-5 border border-border-color/40 shadow-sm space-y-2">
+                <ToggleSwitch 
+                    label="Master Sound" 
+                    isOn={!settings.audio.masterMuted} 
+                    onToggle={() => updateAudio('masterMuted', !settings.audio.masterMuted)} 
+                />
+                
+                {/* Sliders Container */}
+                <div className={`transition-all duration-300 ${settings.audio.masterMuted ? 'opacity-40 grayscale pointer-events-none' : 'opacity-100'}`}>
+                    <div className="h-px bg-border-color/30 my-3" />
+                    <RangeSlider 
+                        label="Music Volume" 
+                        value={settings.audio.musicVolume} 
+                        onChange={(v) => updateAudio('musicVolume', v)}
+                    />
+                    <RangeSlider 
+                        label="SFX Volume" 
+                        value={settings.audio.sfxVolume} 
+                        onChange={(v) => updateAudio('sfxVolume', v)}
+                    />
+                </div>
+            </div>
+        </SettingsSection>
+
+        {/*DIFFICULTY*/}
         <SettingsSection title="Game Difficulty">
-            <div className="grid grid-cols-3 gap-3 p-1 bg-white/5 rounded-2xl border border-white/5">
+            <div className="grid grid-cols-3 gap-3 p-1.5 bg-bg-card/50 rounded-2xl border border-border-color/40">
             {(['EASY', 'MEDIUM', 'HARD'] as Difficulty[]).map((level) => (
                 <DifficultyButton 
                     key={level}
@@ -54,7 +85,7 @@ export const SettingsPage = () => {
             </div>
         </SettingsSection>
 
-        {/* --- 2. GRAPHICS --- */}
+        {/* GRAPHICS & CAMERA */}
         <SettingsSection title="Graphics & Camera">
             <div className="space-y-1">
                 <ToggleSwitch 
@@ -83,7 +114,7 @@ export const SettingsPage = () => {
             )}
         </SettingsSection>
 
-        {/* --- 3. COLORS --- */}
+        {/* COLORS */}
         <SettingsSection title="Customization">
             <div className="space-y-6">
                 <ColorSwatchGroup 


### PR DESCRIPTION
Persist theme settings to localStorage and improve typing for updateSetting. Refactor audio handling across 3D ghosts, food, and game audio hook to use effective master/sfx/music volumes, clamp/zero volumes when muted, and adjust positional audio behavior (including MAX_AUDIBLE_DISTANCE tweak). Add a RangeSlider component and an Audio Configuration section in the Settings page for music/sfx sliders, plus various UI styling refinements. Also include minor code cleanups (formatting, small logic simplifications) and ensure theme resets remove stored settings.