### PR TITLE
Add 2D food components & refactor Food2D

### DIFF
--- a/src/components/Game/Foods/Food2D.tsx
+++ b/src/components/Game/Foods/Food2D.tsx
@@ -1,90 +1,56 @@
-import { useEffect, useState } from 'react';
 import { useTheme } from '../../../context/ThemeContext';
+import { Mchadi2D } from '../Foods/items2D/Mchadi2D';
+import { Kebab2D } from '../Foods/items2D//Kebab2D';
+import { Khinkali2D } from '../Foods/items2D//Khinkali2D';
+import { Khachapuri2D } from '../Foods/items2D/Khachapuri2D'; 
+import { Dot2D } from '../Foods/items2D/Dot2D';
+import { PowerPellet2D } from '../Foods/items2D/PowerPellet2D';
+import { Cherry2D } from '../Foods/items2D/Cherry2D';
+import { Strawberry2D } from '../Foods/items2D/Strawberry2D';
+import { Heart2D } from '../Foods/items2D/Heart2D';
 
 type ConsumableVariant = 'dot' | 'power' | 'cherry' | 'strawberry' | 'life';
 
 interface Food2DProps {
   type: ConsumableVariant;
-  size?: number; 
+  size?: number;
+  themeOverride?: 'classic' | 'labadze'; 
 }
 
-export const Food2D = ({ type, size = 100 }: Food2DProps) => {
-  const [isPowerPelletVisible, setIsPowerPelletVisible] = useState(true);
+export const Food2D = ({ type, size = 100, themeOverride }: Food2DProps) => {
   const { settings } = useTheme();
-  const pelletThemeColor = settings?.foodColor ?? '#fef08a';
+  
+  const currentTheme = themeOverride || settings.gameTheme;
+  const isLabadze = currentTheme === 'labadze';
 
-  useEffect(() => {
-    if (type === 'power') {
-      const blinkIntervalId = setInterval(() => {
-        setIsPowerPelletVisible((prevVisibility) => !prevVisibility);
-      }, 200);
-      return () => clearInterval(blinkIntervalId);
-    }
-  }, [type]);
-
-  const containerStyle = { width: size, height: size };
-
-  if (type === 'dot') {
-    return (
-      <div style={containerStyle} className="flex items-center justify-center">
-        <div className="w-[25%] h-[25%] rounded-sm shadow-sm transition-colors duration-300" style={{ backgroundColor: pelletThemeColor }}/>
-      </div>
-    );
+  if (isLabadze) {
+      switch (type) {
+          case 'dot':
+              return <Mchadi2D size={size * 1.8} />;
+          case 'power':
+              return <Kebab2D size={size * 1.5} />;
+          case 'cherry':
+              return <Khinkali2D size={size * 1.2} />;
+          case 'strawberry':
+              return <Khachapuri2D size={size * 1.3} />; 
+          case 'life':
+              return <Heart2D size={size} />;
+          default:
+              return null;
+      }
   }
-
-  if (type === 'power') {
-    return (
-      <div style={containerStyle} className="flex items-center justify-center">
-        <div 
-          className={`w-[65%] h-[65%] rounded-full transition-all duration-200 ${isPowerPelletVisible ? 'opacity-100 scale-100' : 'opacity-70 scale-90'}`}
-          style={{ backgroundColor: pelletThemeColor, boxShadow: isPowerPelletVisible ? `0 0 15px ${pelletThemeColor}` : 'none' }} 
-        />
-      </div>
-    );
+  switch (type) {
+      case 'dot':
+          return <Dot2D size={size} />;
+      case 'power':
+          return <PowerPellet2D size={size} />;
+      case 'cherry':
+          return <Cherry2D size={size} />;
+      case 'strawberry':
+          return <Strawberry2D size={size} />;
+      case 'life':
+          return <Heart2D size={size} />;
+      default:
+          return null;
   }
-
-  if (type === 'cherry') {
-    return (
-      <svg style={containerStyle} viewBox="0 0 100 100" fill="none">
-        <path d="M50 15 Q 65 40 75 65" stroke="#65a30d" strokeWidth="3" strokeLinecap="round" />
-        <path d="M50 15 Q 35 40 25 65" stroke="#65a30d" strokeWidth="3" strokeLinecap="round" />
-        <circle cx="50" cy="15" r="3" fill="#4d7c0f" />
-        <circle cx="25" cy="70" r="18" fill="#dc2626" />
-        <ellipse cx="18" cy="65" rx="4" ry="6" fill="white" fillOpacity="0.4" transform="rotate(-20 18 65)" /> 
-        <circle cx="75" cy="70" r="18" fill="#dc2626" />
-        <ellipse cx="68" cy="65" rx="4" ry="6" fill="white" fillOpacity="0.4" transform="rotate(-20 68 65)" /> 
-        <path d="M50 15 C 60 5, 75 15, 70 25 C 65 35, 55 25, 50 15" fill="#65a30d"/>
-      </svg>
-    );
-  }
-
-  if (type === 'strawberry') {
-    return (
-      <svg style={containerStyle} viewBox="0 0 100 100" fill="none">
-        <path d="M50 95 C 20 70, 5 50, 15 30 C 20 20, 35 20, 50 35 C 65 20, 80 20, 85 30 C 95 50, 80 70, 50 95 Z" fill="#ef4444" stroke="#b91c1c" strokeWidth="2" strokeLinejoin="round" />
-        <circle cx="30" cy="40" r="1.5" fill="#fef08a" /><circle cx="45" cy="45" r="1.5" fill="#fef08a" /><circle cx="70" cy="40" r="1.5" fill="#fef08a" />
-        <circle cx="25" cy="55" r="1.5" fill="#fef08a" /><circle cx="50" cy="65" r="1.5" fill="#fef08a" /><circle cx="75" cy="55" r="1.5" fill="#fef08a" />
-        <circle cx="40" cy="80" r="1.5" fill="#fef08a" /><circle cx="60" cy="80" r="1.5" fill="#fef08a" />
-        <path d="M50 35 L 40 20 L 25 25 L 35 35 L 50 35 Z" fill="#16a34a" stroke="#15803d" strokeWidth="1" strokeLinejoin="round" />
-        <path d="M50 35 L 60 20 L 75 25 L 65 35 L 50 35 Z" fill="#16a34a" stroke="#15803d" strokeWidth="1" strokeLinejoin="round" />
-        <path d="M50 35 L 50 15 L 45 25 L 55 25 L 50 15 Z" fill="#22c55e" />
-      </svg>
-    );
-  }
-
-  if (type === 'life') {
-    return (
-      <svg style={containerStyle} viewBox="0 0 100 100" fill="none" className="drop-shadow-lg animate-pulse">
-         <path 
-           d="M50 88.9 L44.2 83.6 C23.6 64.9 10 52.6 10 37.5 C10 25.2 19.7 15.5 32 15.5 C38.9 15.5 45.6 18.7 50 23.8 C54.4 18.7 61.1 15.5 68 15.5 C80.3 15.5 90 25.2 90 37.5 C90 52.6 76.4 64.9 55.8 83.6 L50 88.9Z" 
-           fill="#ec4899" 
-           stroke="#be185d" 
-           strokeWidth="3"
-         />
-         <ellipse cx="30" cy="30" rx="8" ry="4" fill="white" fillOpacity="0.4" transform="rotate(-30 30 30)" />
-      </svg>
-    );
-  }
-
-  return null;
 };

--- a/src/components/Game/Foods/items2D/Cherry2D.tsx
+++ b/src/components/Game/Foods/items2D/Cherry2D.tsx
@@ -1,0 +1,27 @@
+interface Cherry2DProps {
+  size: number;
+}
+
+export const Cherry2D = ({ size }: Cherry2DProps) => {
+  return (
+    <div style={{ width: size, height: size }} className="flex items-center justify-center">
+      <svg viewBox="0 0 100 100" fill="none" className="w-full h-full">
+        <path d="M50 15 Q 65 40 75 65" stroke="#65a30d" strokeWidth="3" strokeLinecap="round" />
+        <path d="M50 15 Q 35 40 25 65" stroke="#65a30d" strokeWidth="3" strokeLinecap="round" />
+        
+        <circle cx="50" cy="15" r="3" fill="#4d7c0f" />
+        
+        {/* მარცხენა ალუბალი */}
+        <circle cx="25" cy="70" r="18" fill="#dc2626" />
+        <ellipse cx="18" cy="65" rx="4" ry="6" fill="white" fillOpacity="0.4" transform="rotate(-20 18 65)" /> 
+        
+        {/* მარჯვენა ალუბალი */}
+        <circle cx="75" cy="70" r="18" fill="#dc2626" />
+        <ellipse cx="68" cy="65" rx="4" ry="6" fill="white" fillOpacity="0.4" transform="rotate(-20 68 65)" /> 
+        
+        {/* ფოთოლი */}
+        <path d="M50 15 C 60 5, 75 15, 70 25 C 65 35, 55 25, 50 15" fill="#65a30d"/>
+      </svg>
+    </div>
+  );
+};

--- a/src/components/Game/Foods/items2D/Dot2D.tsx
+++ b/src/components/Game/Foods/items2D/Dot2D.tsx
@@ -1,0 +1,19 @@
+import { useTheme } from '../../../../context/ThemeContext';
+
+interface Dot2DProps {
+  size: number;
+}
+
+export const Dot2D = ({ size }: Dot2DProps) => {
+  const { settings } = useTheme();
+  const color = settings?.foodColor ?? '#fef08a';
+
+  return (
+    <div style={{ width: size, height: size }} className="flex items-center justify-center">
+      <div 
+        className="w-[25%] h-[25%] rounded-sm shadow-sm transition-colors duration-300" 
+        style={{ backgroundColor: color }}
+      />
+    </div>
+  );
+};

--- a/src/components/Game/Foods/items2D/Heart2D.tsx
+++ b/src/components/Game/Foods/items2D/Heart2D.tsx
@@ -1,0 +1,19 @@
+interface Heart2DProps {
+  size: number;
+}
+
+export const Heart2D = ({ size }: Heart2DProps) => {
+  return (
+    <div style={{ width: size, height: size }} className="flex items-center justify-center animate-pulse">
+       <svg viewBox="0 0 100 100" fill="none" className="drop-shadow-lg w-full h-full">
+         <path 
+           d="M50 88.9 L44.2 83.6 C23.6 64.9 10 52.6 10 37.5 C10 25.2 19.7 15.5 32 15.5 C38.9 15.5 45.6 18.7 50 23.8 C54.4 18.7 61.1 15.5 68 15.5 C80.3 15.5 90 25.2 90 37.5 C90 52.6 76.4 64.9 55.8 83.6 L50 88.9Z" 
+           fill="#ec4899" 
+           stroke="#be185d" 
+           strokeWidth="3"
+         />
+         <ellipse cx="30" cy="30" rx="8" ry="4" fill="white" fillOpacity="0.4" transform="rotate(-30 30 30)" />
+      </svg>
+    </div>
+  );
+};

--- a/src/components/Game/Foods/items2D/Kebab2D.tsx
+++ b/src/components/Game/Foods/items2D/Kebab2D.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+
+interface Kebab2DProps {
+  size: number;
+}
+
+export const Kebab2D = ({ size }: Kebab2DProps) => {
+  const [isVisible, setIsVisible] = useState(true);
+
+  // ციმციმის ეფექტი
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setIsVisible((prev) => !prev);
+    }, 200);
+    return () => clearInterval(interval);
+  }, []);
+
+  const opacity = isVisible ? 1 : 0.5;
+
+  return (
+    <div 
+      style={{ width: size, height: size, opacity }} 
+      className="flex items-center justify-center transition-opacity duration-200"
+    >
+      <svg viewBox="0 0 100 100" className="w-full h-full" transform="rotate(-45)">
+        {/* შამფური */}
+        <line x1="50" y1="5" x2="50" y2="95" stroke="#A9A9A9" strokeWidth="4" />
+        
+        {/* ხორცი */}
+        <rect x="35" y="20" width="30" height="60" rx="10" fill="#8B4513" stroke="#5D4037" strokeWidth="2" />
+        
+        {/* გრილის ზოლები */}
+        <path d="M35,35 L65,40" stroke="#3E200A" strokeWidth="2" opacity="0.6" />
+        <path d="M35,50 L65,55" stroke="#3E200A" strokeWidth="2" opacity="0.6" />
+        <path d="M35,65 L65,70" stroke="#3E200A" strokeWidth="2" opacity="0.6" />
+      </svg>
+    </div>
+  );
+};

--- a/src/components/Game/Foods/items2D/Khachapuri2D.tsx
+++ b/src/components/Game/Foods/items2D/Khachapuri2D.tsx
@@ -1,0 +1,64 @@
+interface Khachapuri2DProps {
+  size: number;
+}
+
+export const Khachapuri2D = ({ size }: Khachapuri2DProps) => {
+  return (
+    <div style={{ width: size, height: size }} className="flex items-center justify-center">
+      <svg viewBox="0 0 100 100" className="w-full h-full drop-shadow-md">
+        
+        {/*ცომი*/}
+        <path 
+          d="
+            M 20,40           
+            Q 50,10 80,40     
+            Q 95,45 95,50     
+            Q 95,55 80,60     
+            Q 50,90 20,60     
+            Q 5,55 5,50       
+            Q 5,45 20,40      
+            Z
+          " 
+          fill="#D2691E" 
+          stroke="#8B4513" 
+          strokeWidth="3" 
+          strokeLinejoin="round"
+        />
+        
+        {/*ყველი*/}
+        <path 
+          d="
+            M 25,45 
+            Q 50,25 75,45 
+            Q 85,50 75,55 
+            Q 50,75 25,55 
+            Q 15,50 25,45 
+            Z
+          " 
+          fill="#FFFACD" 
+          opacity="0.95"
+        />
+        
+        {/*კვერცხის გული*/}
+        <circle cx="50" cy="50" r="13" fill="#FFA500" stroke="#FF8C00" strokeWidth="1" />
+        
+        {/*კარაქი*/}
+        <rect 
+            x="35" 
+            y="40" 
+            width="10" 
+            height="8" 
+            rx="1" 
+            fill="#FFFFE0" 
+            stroke="#F0E68C" 
+            strokeWidth="0.5" 
+            transform="rotate(-15 40 44)" 
+        />
+        
+        {/*დეტალები*/}
+        <circle cx="20" cy="50" r="1.5" fill="#8B4513" opacity="0.5" />
+        <circle cx="80" cy="50" r="1.5" fill="#8B4513" opacity="0.5" />
+      </svg>
+    </div>
+  );
+};

--- a/src/components/Game/Foods/items2D/Khinkali2D.tsx
+++ b/src/components/Game/Foods/items2D/Khinkali2D.tsx
@@ -1,0 +1,27 @@
+interface Khinkali2DProps {
+  size: number;
+}
+
+export const Khinkali2D = ({ size }: Khinkali2DProps) => {
+  return (
+    <div style={{ width: size, height: size }} className="flex items-center justify-center">
+      <svg viewBox="0 0 100 100" className="w-full h-full drop-shadow-md">
+        {/* კუჭი */}
+        <path d="M42,20 L58,20 L55,35 L45,35 Z" fill="#F5F5DC" stroke="#D2B48C" strokeWidth="1" />
+        
+        {/* ტანი */}
+        <path 
+          d="M50,35 C25,35 15,50 15,65 C15,85 30,90 50,90 C70,90 85,85 85,65 C85,50 75,35 50,35 Z" 
+          fill="#F5F5DC" 
+          stroke="#D2B48C" 
+          strokeWidth="2" 
+        />
+        
+        {/* ნაოჭები */}
+        <path d="M50,35 L50,80" stroke="#D2B48C" strokeWidth="1" fill="none" />
+        <path d="M40,36 L30,70" stroke="#D2B48C" strokeWidth="1" fill="none" />
+        <path d="M60,36 L70,70" stroke="#D2B48C" strokeWidth="1" fill="none" />
+      </svg>
+    </div>
+  );
+};

--- a/src/components/Game/Foods/items2D/Mchadi2D.tsx
+++ b/src/components/Game/Foods/items2D/Mchadi2D.tsx
@@ -1,0 +1,72 @@
+interface Mchadi2DProps {
+  size: number;
+}
+
+export const Mchadi2D = ({ size }: Mchadi2DProps) => {
+  return (
+    <div style={{ width: size, height: size }} className="flex items-center justify-center">
+      <svg viewBox="0 0 100 100" className="w-full h-full drop-shadow-md">
+        <defs>
+          {/*  ძირითადი ფერი */}
+          <radialGradient id="realMchadiGradient" cx="50%" cy="50%" r="55%" fx="50%" fy="50%">
+            <stop offset="40%" stopColor="#FDD835" />  
+            <stop offset="80%" stopColor="#FBC02D" />  
+            <stop offset="100%" stopColor="#E65100" /> 
+          </radialGradient>
+
+          {/* ტექსტურა*/}
+          <filter id="grainyTexture">
+            <feTurbulence type="fractalNoise" baseFrequency="0.8" numOctaves="3" result="noise" />
+            <feColorMatrix type="matrix" values="0 0 0 0 0.6  0 0 0 0 0.4  0 0 0 0 0.2  0 0 0 0.3 0" />
+            <feComposite operator="in" in2="SourceGraphic" result="composite" />
+            <feBlend mode="multiply" in="composite" in2="SourceGraphic" />
+          </filter>
+
+          {/* ბუნდოვანება ჩამწვარი ლაქებისთვის */}
+          <filter id="charBlur">
+            <feGaussianBlur in="SourceGraphic" stdDeviation="1.5" />
+          </filter>
+        </defs>
+
+        {/* დაჯგუფება და როტაცია */}
+        <g transform="rotate(-35 50 50)">
+            
+            {/* ძირითადი ფორმა: არასწორი ოვალი ) */}
+            <path 
+              d="
+                M 10,50 
+                C 10,25 35,18 50,18 
+                C 75,18 95,30 95,50 
+                C 95,75 70,82 50,82 
+                C 30,82 10,70 10,50 
+                Z
+              " 
+              fill="url(#realMchadiGradient)" 
+              stroke="#BF360C" 
+              strokeWidth="0.5"
+              strokeOpacity="0.4"
+              filter="url(#grainyTexture)" 
+            />
+
+            {/* ჩამწვარი ლაქები  */}
+            <g fill="#3E2723" opacity="0.6" filter="url(#charBlur)" style={{ mixBlendMode: 'multiply' }}>
+               {/* დიდი ლაქა ცენტრში/მარცხნივ */}
+               <path d="M 35,45 Q 45,40 50,50 Q 45,60 35,55 Z" />
+               
+               {/* პატარა ლაქები */}
+               <circle cx="70" cy="40" r="4" />
+               <circle cx="60" cy="65" r="3" />
+               <ellipse cx="25" cy="50" rx="4" ry="6" />
+               <circle cx="80" cy="55" r="2.5" />
+            </g>
+
+            {/* ბზარები */}
+            <path d="M 12,50 Q 20,50 25,52" stroke="#E65100" strokeWidth="0.5" fill="none" opacity="0.5" />
+            <path d="M 93,50 Q 85,50 80,48" stroke="#E65100" strokeWidth="0.5" fill="none" opacity="0.5" />
+            <path d="M 50,82 Q 50,75 52,70" stroke="#E65100" strokeWidth="0.5" fill="none" opacity="0.3" />
+
+        </g>
+      </svg>
+    </div>
+  );
+};

--- a/src/components/Game/Foods/items2D/PowerPellet2D.tsx
+++ b/src/components/Game/Foods/items2D/PowerPellet2D.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { useTheme } from '../../../../context/ThemeContext';
+
+interface PowerPellet2DProps {
+  size: number;
+}
+
+export const PowerPellet2D = ({ size }: PowerPellet2DProps) => {
+  const [isVisible, setIsVisible] = useState(true);
+  const { settings } = useTheme();
+  const color = settings?.foodColor ?? '#fef08a';
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setIsVisible((prev) => !prev);
+    }, 200);
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <div style={{ width: size, height: size }} className="flex items-center justify-center">
+      <div 
+        className={`w-[65%] h-[65%] rounded-full transition-all duration-200 ${isVisible ? 'opacity-100 scale-100' : 'opacity-70 scale-90'}`}
+        style={{ 
+          backgroundColor: color, 
+          boxShadow: isVisible ? `0 0 15px ${color}` : 'none' 
+        }} 
+      />
+    </div>
+  );
+};

--- a/src/components/Game/Foods/items2D/Strawberry2D.tsx
+++ b/src/components/Game/Foods/items2D/Strawberry2D.tsx
@@ -1,0 +1,24 @@
+interface Strawberry2DProps {
+  size: number;
+}
+
+export const Strawberry2D = ({ size }: Strawberry2DProps) => {
+  return (
+    <div style={{ width: size, height: size }} className="flex items-center justify-center">
+      <svg viewBox="0 0 100 100" fill="none" className="w-full h-full">
+        {/* მარწყვის ტანი */}
+        <path d="M50 95 C 20 70, 5 50, 15 30 C 20 20, 35 20, 50 35 C 65 20, 80 20, 85 30 C 95 50, 80 70, 50 95 Z" fill="#ef4444" stroke="#b91c1c" strokeWidth="2" strokeLinejoin="round" />
+        
+        {/* კურკები */}
+        <circle cx="30" cy="40" r="1.5" fill="#fef08a" /><circle cx="45" cy="45" r="1.5" fill="#fef08a" /><circle cx="70" cy="40" r="1.5" fill="#fef08a" />
+        <circle cx="25" cy="55" r="1.5" fill="#fef08a" /><circle cx="50" cy="65" r="1.5" fill="#fef08a" /><circle cx="75" cy="55" r="1.5" fill="#fef08a" />
+        <circle cx="40" cy="80" r="1.5" fill="#fef08a" /><circle cx="60" cy="80" r="1.5" fill="#fef08a" />
+        
+        {/* ფოთლები */}
+        <path d="M50 35 L 40 20 L 25 25 L 35 35 L 50 35 Z" fill="#16a34a" stroke="#15803d" strokeWidth="1" strokeLinejoin="round" />
+        <path d="M50 35 L 60 20 L 75 25 L 65 35 L 50 35 Z" fill="#16a34a" stroke="#15803d" strokeWidth="1" strokeLinejoin="round" />
+        <path d="M50 35 L 50 15 L 45 25 L 55 25 L 50 15 Z" fill="#22c55e" />
+      </svg>
+    </div>
+  );
+};

--- a/src/pages/Showcases/FoodShowcase.tsx
+++ b/src/pages/Showcases/FoodShowcase.tsx
@@ -9,7 +9,6 @@ import { useTranslation } from 'react-i18next';
 
 type FoodType = 'dot' | 'power' | 'cherry' | 'strawberry' | 'life';
 type ThemeVariant = 'classic' | 'labadze';
-
 type ButtonColor = 'red' | 'yellow' | 'gray' | 'pink' | 'blue' | 'green';
 
 interface FoodItemConfig {
@@ -36,31 +35,32 @@ export const FoodShowcase = () => {
   const [localIs3D, setLocalIs3D] = useState(true);
 
   const allFoods: FoodItemConfig[] = [
-    // --- Dots ---
+    //  Dots 
     { label: 'Dot', type: 'dot', theme: 'classic', icon: '•', color: 'gray' },
     { label: 'Mchadi', type: 'dot', theme: 'labadze', icon: '🌽', color: 'yellow' },
     
-    // --- Power ---
+    //  Power 
     { label: 'Power', type: 'power', theme: 'classic', icon: '⚡', color: 'gray' },
     { label: 'Kebab', type: 'power', theme: 'labadze', icon: '🍢', color: 'yellow' },
 
-    // --- Cherry / Khinkali ---
+    //  Cherry / Khinkali 
     { label: 'Cherry', type: 'cherry', theme: 'classic', icon: '🍒', color: 'red' },
     { label: 'Khinkali', type: 'cherry', theme: 'labadze', icon: '🥟', color: 'yellow' },
 
-    // --- Strawberry / Khachapuri ---
+    //  Strawberry / khachapuri 
     { label: 'Strawberry', type: 'strawberry', theme: 'classic', icon: '🍓', color: 'red' },
-    { label: 'Khachapuri', type: 'strawberry', theme: 'labadze', icon: '🧀', color: 'yellow' },
+    { label: 'khachapuri', type: 'strawberry', theme: 'labadze', icon: '🧀', color: 'yellow' },
 
-    // --- Life ---
-    { label: 'Life', type: 'life', theme: 'classic', icon: '❤️', color: 'pink' },
+    //  Life 
+    { label: 'Life', type: 'life', theme: 'classic', icon: '❤️', color: 'pink' }
   ];
 
+  // Sidebar
   const Sidebar = (
     <div>
       <ModeToggle is3D={localIs3D} onToggle={setLocalIs3D} isDark={isDark} />
 
-      <ShowcaseSectionTitle title={t('showcase.inspect')} />
+      <ShowcaseSectionTitle title={t('showcase.inspect') || "Inspect Items"} />
       
       <div className="flex flex-col gap-2 h-[calc(100vh-250px)] overflow-y-auto pr-2 custom-scrollbar">
         {allFoods.map((item, index) => {
@@ -80,8 +80,8 @@ export const FoodShowcase = () => {
         })}
       </div>
       
-      <div className="mt-4 text-xs text-gray-400 text-center">
-        {t('showcase.visual_disclaimer')}
+      <div className="mt-4 text-xs text-gray-400 text-center opacity-60">
+        Select an item to view its 2D and 3D variants.
       </div>
     </div>
   );
@@ -90,23 +90,26 @@ export const FoodShowcase = () => {
     <ShowcaseCanvas isDark={isDark} scale={3}>
         <Food3D 
             consumableVariant={selectedItem.type} 
-            themeOverride={selectedItem.theme} 
+            themeOverride={selectedItem.theme}  
         />
     </ShowcaseCanvas>
   ) : (
-    <div className="flex items-center justify-center h-full">
-         <div className="z-10 transform scale-150 p-12 bg-white/5 rounded-3xl backdrop-blur-xl border border-white/10 shadow-2xl flex flex-col items-center gap-4">
-            <Food2D type={selectedItem.type} size={150} />
-            <p className="text-white/50 text-sm font-mono">
-                (2D View always uses Classic sprites)
-            </p>
+    //  2D VIEW 
+    <div className="flex items-center justify-center h-full w-full bg-black/5">
+         <div className="z-10 transform scale-150 p-12 bg-white/5 rounded-3xl backdrop-blur-xl border border-white/10 shadow-2xl flex flex-col items-center gap-6">
+            
+            <Food2D 
+                type={selectedItem.type} 
+                size={150} 
+                themeOverride={selectedItem.theme}
+            />
          </div>
     </div>
   );
 
   return (
     <ShowcaseLayout 
-      title={t('nav.food_lab')} 
+      title={t('nav.food_lab') || "Food Lab"} 
       icon="🍽️" 
       sidebarContent={Sidebar} 
       mainContent={MainContent} 


### PR DESCRIPTION
Introduce individual 2D food components (Cherry2D, Dot2D, Heart2D, Kebab2D, Khachapuri2D, Khinkali2D, Mchadi2D, PowerPellet2D, Strawberry2D) and refactor Food2D to import and render them. Food2D now accepts a themeOverride ('classic' | 'labadze') and delegates per-item rendering/animations to the new components (removing inline SVG/animation logic from Food2D). Update FoodShowcase to list labadze variants, pass themeOverride to Food2D, and tweak sidebar/main UI copy and layout for the 2D preview.