### PR TITLE
Add Reaper2D and refactor Jafara2D/Ghost2D

### DIFF
--- a/src/components/Game/2D/Characters/Jafara2D.tsx
+++ b/src/components/Game/2D/Characters/Jafara2D.tsx
@@ -1,103 +1,97 @@
-
-interface JafaraProps {
+interface Jafara2DProps {
   size?: number;
-  isScared?: boolean;
 }
 
-export const Jafara2D = ({ size = 100, isScared }: JafaraProps) => {
-  // ნარინჯისფერი ფონი (Jafara Theme)
-  const bgColor = isScared ? '#1a1a2e' : '#F28C28';
+export const Jafara2D = ({ size = 100 }: Jafara2DProps) => (
+  <svg width={size} height={size} viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <clipPath id="circleViewJafara">
+        <circle cx="50" cy="50" r="48" />
+      </clipPath>
+      
+      <radialGradient id="faceGradientJafara" cx="50%" cy="35%" r="65%" fx="50%" fy="30%">
+        <stop offset="0%" stopColor="#ffe0d0" />
+        <stop offset="100%" stopColor="#e8b99a" />
+      </radialGradient>
 
-  return (
-    <div style={{ width: size, height: size }}>
-      <svg viewBox="0 0 100 100" className="w-full h-full" xmlns="http://www.w3.org/2000/svg">
-        <defs>
-          <clipPath id="circleClipJafara">
-            <circle cx="50" cy="50" r="48" />
-          </clipPath>
-          
-          {/* სახის კანის ტონი */}
-          <radialGradient id="skinGradient" cx="50%" cy="40%" r="50%">
-            <stop offset="0%" stopColor="#e8b99a" />
-            <stop offset="100%" stopColor="#d19a78" />
-          </radialGradient>
+      {/* იშვიათი თმის ეფექტი ზედა ნაწილში */}
+      <pattern id="stubblePattern" x="0" y="0" width="2" height="2" patternUnits="userSpaceOnUse">
+        <circle cx="1" cy="1" r="0.7" fill="#1a1a1a" opacity="0.4" />
+      </pattern>
+    </defs>
 
-          {/* პიჯაკის გრადიენტი */}
-          <linearGradient id="suitGradient" x1="0%" y1="0%" x2="0%" y2="100%">
-            <stop offset="0%" stopColor="#1e2445" />
-            <stop offset="100%" stopColor="#101428" />
-          </linearGradient>
-        </defs>
+    {/* ნარინჯისფერი ფონი */}
+    <circle cx="50" cy="50" r="48" fill="#F28C28" stroke="#c2410c" strokeWidth="2" />
 
-        {/* ნარინჯისფერი ჩარჩო/ფონი */}
-        <circle cx="50" cy="50" r="48" fill={bgColor} stroke="#2d2d2d" strokeWidth="1" />
+    <g clipPath="url(#circleViewJafara)">
+      
+      {/* კისერი */}
+      <path d="M42 75 L 42 95 L 58 95 L 58 75 Z" fill="#d19a78" />
 
-        {!isScared && (
-          <g clipPath="url(#circleClipJafara)">
-            
-            {/* პიჯაკი (Suit) */}
-            <path d="M10 90 Q 50 75 90 90 L 100 110 L 0 110 Z" fill="url(#suitGradient)" />
-            
-            {/* პერანგი (Shirt) */}
-            <path d="M38 82 L 50 98 L 62 82 L 50 110 Z" fill="#FFFFFF" />
-            
-            {/* ჰალსტუხი (Tie) */}
-            <path d="M47 90 L 50 94 L 53 90 L 53 110 L 47 110 Z" fill="#1a1a1a" />
-            <path d="M47 88 L 53 88 L 52 92 L 48 92 Z" fill="#1a1a1a" />
+      {/* პერანგის საყელო */}
+      <path d="M38 88 L 62 88 L 50 100 Z" fill="#FFFFFF" />
 
-            {/* კისერი */}
-            <path d="M42 75 L 42 85 Q 50 90 58 85 L 58 75 Z" fill="#c28e73" />
+      {/*  თავის ფორმა: მომრგვალებული ქალა და ვიწრო ნიკაპი  */}
+      <path 
+        d="M25 40 
+           C 25 10, 75 10, 75 40 
+           C 75 55, 65 85, 50 85 
+           C 35 85, 25 55, 25 40 Z" 
+        fill="url(#faceGradientJafara)" 
+      />
 
-            {/* თავის ფორმა (უფრო მასიური) */}
-            <path 
-              d="M32 40 C 32 15 38 12 50 12 C 62 12 68 15 68 40 C 68 65 62 82 50 82 C 38 82 32 65 32 40 Z" 
-              fill="url(#skinGradient)" 
-            />
+      {/*  ტანსაცმელი  */}
+      <path d="M5 92 Q 50 105 95 92 V 110 H 5 V 92 Z" fill="#1a1a1a" /> 
+      <path d="M40 88 L 50 98 L 60 88 V 110 H 40 V 88 Z" fill="#FFFFFF" />
+      <path d="M44 90 L 50 93 L 56 90 L 56 95 L 50 93 L 44 95 V 90 Z" fill="#000000" />
+      <circle cx="50" cy="93" r="1.2" fill="#333333" />
 
-            {/* თმა (მოკლე, კლასიკური) */}
-            <path 
-              d="M32 35 Q 32 12 50 12 Q 68 12 68 35 L 68 40 Q 50 32 32 40 Z" 
-              fill="#261a12" 
-            />
-            
-            {/* წვერი (Jafara's Signature Beard) */}
-            <path 
-              d="M32 50 Q 32 85 50 85 Q 68 85 68 50 Q 50 55 32 50 Z" 
-              fill="#261a12" 
-            />
+      {/* იშვიათი თმა ქალაზე */}
+      <path 
+      d="M26 38 C 26 12, 74 12, 74 38 C 74 22, 26 22, 26 38 Z" 
+      fill="url(#stubblePattern)" 
+    />
 
-            {/* ულვაში */}
-            <path 
-              d="M38 58 Q 50 65 62 58 Q 50 60 38 58" 
-              fill="#1a110a" 
-            />
+      {/* წარბები */}
+      <path d="M32 38 Q 40 34 46 37" stroke="#1a1a1a" strokeWidth="3" fill="none" strokeLinecap="round" />
+      <path d="M54 37 Q 60 34 68 38" stroke="#1a1a1a" strokeWidth="3" fill="none" strokeLinecap="round" />
 
-            {/* თვალები */}
-            <circle cx="42" cy="45" r="2.2" fill="#1a1a1a" />
-            <circle cx="58" cy="45" r="2.2" fill="#1a1a1a" />
+      {/* თვალები */}
+      <circle cx="39" cy="46" r="2.8" fill="#2d1b0e" />
+      <circle cx="61" cy="46" r="2.8" fill="#2d1b0e" />
 
-            {/* წარბები (უფრო მკვეთრი) */}
-            <path d="M36 40 Q 42 37 46 39" stroke="#1a110a" strokeWidth="2" fill="none" />
-            <path d="M54 39 Q 58 37 64 40" stroke="#1a110a" strokeWidth="2" fill="none" />
+      {/* ცხვირი */}
+      <path d="M50 45 Q 48 58 46 60 L 50 63 L 54 60" fill="none" stroke="#d19a78" strokeWidth="1.8" opacity="0.8" />
 
-            {/* ცხვირი */}
-            <path d="M48 58 Q 50 62 52 58" stroke="#8d6e63" strokeWidth="1" fill="none" />
+      {/*  წვერი და ულვაში: ზუსტად მიყვება ვიწრო ნიკაპს  */}
+      <g fill="#1a1a1a">
+        {/* ულვაში */}
+        <path d="M35 60 Q 50 56 65 60 L 67 64 Q 50 61 33 64 Z" 
+        transform="translate(0, 5)"
+        />
+        
+        {/* სრული წვერი, რომელიც ვიწროვდება ნიკაპთან */}
+        <path d="M28 55 
+                 C 28 75, 40 85, 50 85 
+                 C 60 85, 72 75, 72 55 
+                 L 66 58 
+                 C 62 70, 55 75, 50 75 
+                 C 45 75, 38 70, 34 58 
+                 Z" />
+                 
+        {/* დამაკავშირებელი ხაზი (Goatee ჩარჩო) */}
+        <path d="M35 60 L 37 68 M 65 60 L 63 68" stroke="#1a1a1a" strokeWidth="2.5" />
+      </g>
 
-          </g>
-        )}
+      {/*  პირი და ტუჩები  */}
+      <g transform="translate(0, 2)">
+        <path d="M43 66 Q 50 67 57 66" stroke="#d19a78" strokeWidth="1.2" fill="none" />
+        <path d="M43 67 Q 50 68 57 67" stroke="#3e2723" strokeWidth="1" fill="none" />
+        <path d="M44 68 Q 50 71 56 68" stroke="#e57373" strokeWidth="1.5" fill="none" opacity="0.5" />
+        {/* ნიკაპის ჩრდილი წვერის ქვეშ */}
+        <path d="M49 71 L 50 72 L 51 71" fill="#000" opacity="0.6" />
+      </g>
 
-        {isScared && (
-          <g clipPath="url(#circleClipJafara)">
-             {/* "შეშინებული" ვერსია პიჯაკში */}
-             <path d="M10 90 Q 50 75 90 90 L 100 110 L 0 110 Z" fill="#111" />
-             <circle cx="35" cy="45" r="6" fill="white" />
-             <circle cx="65" cy="45" r="6" fill="white" />
-             <circle cx="35" cy="45" r="2" fill="#2121DE" />
-             <circle cx="65" cy="45" r="2" fill="#2121DE" />
-             <path d="M40 70 Q 50 60 60 70" stroke="white" strokeWidth="2" fill="none" />
-          </g>
-        )}
-      </svg>
-    </div>
-  );
-};
+    </g>
+  </svg>
+);

--- a/src/components/Game/2D/Ghost2D.tsx
+++ b/src/components/Game/2D/Ghost2D.tsx
@@ -4,6 +4,7 @@ import { Iko2D } from '../2D/Characters/Iko2D';
 import { Jafara2D } from '../2D/Characters/Jafara2D';
 import { GhostIcon } from './icons/GhostIcon';
 import { EyesIcon } from './icons/EyesIcon';
+import { Reaper2D } from './icons/Reaper2D';
 
 interface Ghost2DProps {
   variant: number;
@@ -14,19 +15,26 @@ interface Ghost2DProps {
 export const Ghost2D = ({ variant, color, size = 100 }: Ghost2DProps) => {
   switch (variant) {
     case 1:
-      return <GhostIcon className='' color={color} />;
+      return <GhostIcon className="w-full h-full" color={color} />;
+
     case 2:
-      return <div style={{color: 'white'}}></div>;
+      return <Reaper2D size={size} color={color} />;
+
     case 3:
-      return <EyesIcon className='' />;
+      return <EyesIcon className="w-full h-full" />;
+
     case 4:
       return <Kakaba2D size={size} />;
+
     case 5:
       return <Janela2D size={size} />;
+
     case 6:
       return <Iko2D size={size} />;
+
     case 7:
       return <Jafara2D size={size} />;
+
     default:
       return null;
   }

--- a/src/components/Game/2D/icons/Reaper2D.tsx
+++ b/src/components/Game/2D/icons/Reaper2D.tsx
@@ -1,0 +1,100 @@
+interface Reaper2DProps {
+  size?: number;
+  color?: string;
+}
+
+export const Reaper2D = ({ size = 100, color = '#ef4444' }: Reaper2DProps) => {
+  return (
+    <div style={{ width: size, height: size }}>
+      <svg 
+        viewBox="0 0 150 150" 
+        className="w-full h-full drop-shadow-lg" 
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <defs>
+          <linearGradient id="robeGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+            <stop offset="0%" stopColor="#2a2a2a" />
+            <stop offset="100%" stopColor="#050505" />
+          </linearGradient>
+
+          <linearGradient id="bladeMetal" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0%" stopColor="#e5e7eb" />
+            <stop offset="50%" stopColor="#9ca3af" />
+            <stop offset="100%" stopColor="#4b5563" />
+          </linearGradient>
+
+          <filter id="eyeGlow">
+            <feGaussianBlur stdDeviation="1.5" result="coloredBlur"/>
+            <feMerge>
+              <feMergeNode in="coloredBlur"/>
+              <feMergeNode in="SourceGraphic"/>
+            </feMerge>
+          </filter>
+        </defs>
+
+        <g transform="translate(25, 25)">
+            
+            {/*  ცელის ტარი  */}
+            <line 
+            x1="20" y1="0"  
+            x2="20" y2="100" 
+            stroke="#5D4037" 
+            strokeWidth="4" 
+            strokeLinecap="round" 
+            />
+            
+            {/*  ცელის პირი  */}
+            <path 
+            d="M 20 5 Q 55 -5 85 20 L 75 25 Q 50 10 22 12 Z" 
+            fill="url(#bladeMetal)" 
+            stroke="#374151" 
+            strokeWidth="1"
+            />
+            <rect x="18" y="8" width="5" height="6" fill="#4B5563" />
+
+
+            {/*  სხეული  */}
+            <path 
+            d="M 55 20 
+                C 35 20, 30 45, 35 95 
+                L 45 90 L 55 95 L 65 90 L 75 95 
+                C 80 50, 85 30, 62 20 Z" 
+            fill="url(#robeGradient)" 
+            stroke="#000" 
+            strokeWidth="1"
+            />
+
+            {/* კაპიუშონის შიდა მხარე */}
+            <path 
+            d="M 40 30 
+                C 40 30, 55 20, 70 30 
+                C 70 55, 65 65, 55 65 
+                C 45 65, 40 55, 40 30 Z" 
+            fill="#000000" 
+            opacity="0.9"
+            />
+
+            {/*  თვალები  */}
+            <g filter="url(#eyeGlow)">
+            <circle cx="48" cy="45" r="3" fill={color} />
+            <circle cx="62" cy="45" r="3" fill={color} />
+            </g>
+
+
+            {/*  ხელი და მკლავი  */}
+            <path 
+            d="M 40 60 Q 30 60 20 60" 
+            stroke="#050505" 
+            strokeWidth="6" 
+            strokeLinecap="round" 
+            />
+            <circle cx="20" cy="60" r="4.5" fill="#050505" />
+            <path d="M 18 58 L 22 58" stroke="#444" strokeWidth="1" />
+            <path d="M 18 60 L 22 60" stroke="#444" strokeWidth="1" />
+            <path d="M 18 62 L 22 62" stroke="#444" strokeWidth="1" />
+        </g>
+
+      </svg>
+    </div>
+  );
+};


### PR DESCRIPTION
Introduce a new Reaper2D SVG icon component (size/color props) and wire it into Ghost2D as variant 2. Refactor Jafara2D: rename props to Jafara2DProps, remove the isScared conditional, and replace the previous JSX with a single self-contained SVG using gradients, patterns and simplified markup. Update Ghost2D to import Reaper2D, normalize className/size usage for returned icons and route variants to their respective 2D components. NOTE: removing the isScared prop in Jafara2D is a breaking change for any callers relying on that behavior.