### PR TITLE
Add ClassicPacman2D, Labadze2D & model switching

### DIFF
--- a/src/components/Game/2D/Characters/ClassicPacman2D.tsx
+++ b/src/components/Game/2D/Characters/ClassicPacman2D.tsx
@@ -1,0 +1,21 @@
+
+export const ClassicPacman2D = () => {
+  return (
+    <svg viewBox="0 0 100 100" className="w-full h-full">
+        <path fill="#FFD700">
+          <animate 
+            attributeName="d" 
+            values="
+              M50 50 L100 50 A50 50 0 1 1 100 49.9 Z;
+              M50 50 L85 85 A50 50 0 1 1 85 15 Z;
+              M50 50 L100 50 A50 50 0 1 1 100 49.9 Z
+            "
+            dur="0.25s"  
+            repeatCount="indefinite"
+            keyTimes="0; 0.5; 1"
+            calcMode="discrete" 
+          />
+        </path>
+      </svg>
+  );
+};

--- a/src/components/Game/2D/Characters/Labadze2D.tsx
+++ b/src/components/Game/2D/Characters/Labadze2D.tsx
@@ -1,54 +1,86 @@
-import { useMemo } from 'react';
-
 interface Labadze2DProps {
-  size: number;
-  heading?: string; // PlayerHeading ტიპი შეგიძლია შემოიტანო თუ გინდა
+  size?: number;
 }
 
-export const Labadze2D = ({ size, heading = 'RIGHT' }: Labadze2DProps) => {
-  // როტაცია მოძრაობის მიხედვით
-  const rotation = useMemo(() => {
-    switch (heading) {
-      case 'UP': return -90;
-      case 'DOWN': return 90;
-      case 'LEFT': return 180;
-      case 'RIGHT': return 0;
-      default: return 0;
-    }
-  }, [heading]);
+export const Labadze2D = ({ size = 100 }: Labadze2DProps) => {
+  const bgColor = "#FFD700";
+  const strokeColor = "#ffbb00";
+  const skinGradientId = "skinGradientMassiveForeheadAnimation";
 
   return (
-    <div style={{ width: size, height: size }} className="flex items-center justify-center">
-      <svg 
-        viewBox="0 0 100 100" 
-        className="w-full h-full drop-shadow-md transition-transform duration-100"
-        transform={`rotate(${rotation})`}
-      >
-        {/* 1. სახე/თავი (ყვითელი ან ხორცისფერი #FFCC80) */}
-        <circle cx="50" cy="50" r="45" fill="#FFCC80" stroke="#E65100" strokeWidth="2" />
+    <svg width={size} height={size} viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <clipPath id="circleViewLabadzeAnimated">
+          <circle cx="50" cy="50" r="48" />
+        </clipPath>
+        <radialGradient id={skinGradientId} cx="50%" cy="30%" r="70%" fx="50%" fy="15%">
+          <stop offset="0%" stopColor="#f5d0c5" />
+          <stop offset="70%" stopColor="#dcb3a3" />
+          <stop offset="100%" stopColor="#cfa695" />
+        </radialGradient>
+      </defs>
 
-        {/* 2. თმა (აქ შეგიძლია შეცვალო ფერი და ფორმა) */}
-        {/* მაგალითად: მოკლე შავი თმა */}
-        <path d="M 15,35 Q 50,5 85,35" stroke="black" strokeWidth="12" strokeLinecap="round" fill="none" />
+      <circle cx="50" cy="50" r="48" fill={bgColor} stroke={strokeColor} strokeWidth="2" />
+
+      <g clipPath="url(#circleViewLabadzeAnimated)">
         
-        {/* 3. სათვალე (თუ ლაბაძეს უკეთია, დატოვე, თუ არა - წაშალე) */}
-        <g stroke="black" strokeWidth="2" fill="none">
-             <circle cx="35" cy="45" r="10" fill="white" opacity="0.5" />
-             <circle cx="65" cy="45" r="10" fill="white" opacity="0.5" />
-             <line x1="45" y1="45" x2="55" y2="45" />
+        {/* შუბლი და თხემი */}
+        <path d="M 16 50 C 10 -10, 90 -10, 84 50 C 80 88, 68 96, 50 96 C 32 96, 20 88, 16 50 Z" fill={`url(#${skinGradientId})`} />
+
+        {/* თმის ღინღლები */}
+        <g stroke="#9ca3af" strokeWidth="0.8" fill="none" opacity="0.6" strokeLinecap="round">
+            <path d="M 17 40 Q 15 38 16 36 M 18 32 Q 15 30 17 28 M 20 25 Q 18 23 20 21 M 23 18 Q 21 15 24 14" />
+            <path d="M 83 40 Q 85 38 84 36 M 82 32 Q 85 30 83 28 M 80 25 Q 82 23 80 21 M 77 18 Q 79 15 76 14" />
+            <path d="M 30 14 Q 31 11 33 13 M 38 10 Q 39 7 41 9 M 48 8 Q 50 5 52 7 M 58 8 Q 59 5 61 7 M 68 12 Q 69 9 71 11" />
+            <path d="M 25 22 Q 26 20 28 21 M 35 17 Q 36 15 38 16 M 45 14 Q 46 12 48 13 M 55 14 Q 56 12 58 13 M 65 17 Q 66 15 68 16 M 75 22 Q 74 20 72 21" opacity="0.4" />
         </g>
 
-        {/* 4. თვალები */}
-        <circle cx="35" cy="45" r="3" fill="black" />
-        <circle cx="65" cy="45" r="3" fill="black" />
+        {/* სახის ნაკვთები */}
+        <g strokeLinecap="round" strokeLinejoin="round">
+            <path d="M 30 48 Q 38 43 46 48" stroke="#4a332a" strokeWidth="3" fill="none" />
+            <path d="M 54 48 Q 62 43 70 48" stroke="#4a332a" strokeWidth="3" fill="none" />
 
-        {/* 5. პირი (Pacman-ის სტილში ამოჭრილი) */}
-        {/* ეს path ხატავს პირს, რომელიც ოდნავ ღიაა */}
-        <path d="M 50,50 L 90,30 L 90,70 Z" fill="#D32F2F" />
+            <ellipse cx="38" cy="56" rx="5" ry="3.5" fill="#ffffff" />
+            <circle cx="38" cy="56" r="2.2" fill="#6b8e9e" />
+            <circle cx="38" cy="56" r="1" fill="#000000" />
+            <ellipse cx="62" cy="56" rx="5" ry="3.5" fill="#ffffff" />
+            <circle cx="62" cy="56" r="2.2" fill="#6b8e9e" />
+            <circle cx="62" cy="56" r="1" fill="#000000" />
+            
+            <path d="M 33 61 Q 38 65 43 61" stroke="#cfa695" strokeWidth="1.2" fill="none" opacity="0.7"/>
+            <path d="M 57 61 Q 62 65 67 61" stroke="#cfa695" strokeWidth="1.2" fill="none" opacity="0.7"/>
+            <path d="M 50 51 L 50 72" stroke="#cfa695" strokeWidth="2" fill="none" />
+            <path d="M 44 74 Q 50 80 56 74" stroke="#b37e66" strokeWidth="2" fill="none" />
+            <path d="M 36 70 Q 30 82 36 90" stroke="#b37e66" strokeWidth="1.5" fill="none" opacity="0.6" />
+            <path d="M 64 70 Q 70 82 64 90" stroke="#b37e66" strokeWidth="1.5" fill="none" opacity="0.6" />
 
-        {/* 6. წვერი (თუ აქვს) */}
-        <path d="M 30,70 Q 50,85 70,70" stroke="black" strokeWidth="3" fill="none" />
-      </svg>
-    </div>
+            {/* ანიმირებული პირი */}
+            <g>
+              <path d="M 38 84 Q 50 87 62 84" stroke="#8c5e4a" strokeWidth="2.2" fill="none" />
+              <ellipse cx="50" cy="85" rx="11" fill="#3e2723">
+                <animate
+                  attributeName="ry"
+                  values="0.5; 7; 0.5"
+                  dur="0.25s"
+                  repeatCount="indefinite"
+                  calcMode="spline"
+                  keySplines="0.5 0 0.5 1; 0.5 0 0.5 1"
+                />
+              </ellipse>
+            </g>
+        </g>
+
+        {/* ტანი */}
+        <g transform="translate(0, 94)">
+            <path d="M 25 0 Q 50 6 75 0 L 85 20 H 15 Z" fill="#1a1a1a" />
+            <path d="M 42 0 L 50 4 L 58 0 V 10 H 42 Z" fill="#FFFFFF" />
+            <g fill="#111111">
+                <path d="M 50 3 L 44 1 V 5 L 50 3 Z" />
+                <path d="M 50 3 L 56 1 V 5 L 50 3 Z" />
+                <rect x="48.5" y="2" width="3" height="2" rx="0.5" />
+            </g>
+        </g>
+      </g>
+    </svg>
   );
 };

--- a/src/components/Game/Player/Pacman2D.tsx
+++ b/src/components/Game/Player/Pacman2D.tsx
@@ -1,50 +1,54 @@
 import { useMemo } from 'react';
+import { useTheme } from '../../../context/ThemeContext';
 import type { PlayerHeading } from '../../../hooks/usePlayerHeading';
+import { Labadze2D } from '../2D/Characters/Labadze2D'; 
+import { ClassicPacman2D } from '../2D/Characters/ClassicPacman2D';
 
 interface Pacman2DProps {
   size: number;
   heading?: PlayerHeading;
+  forceModel?: 'classic' | 'labadze'; 
 }
 
-export const Pacman2D = ({ size, heading = 'RIGHT' }: Pacman2DProps) => {
-  const duration = "0.25s";
+export const Pacman2D = ({ size, heading = 'RIGHT', forceModel }: Pacman2DProps) => {
+  const { settings } = useTheme();
+  const activeModel = forceModel || settings.gameTheme;
 
-  const rotationTransform = useMemo(() => {
-    switch (heading) {
-      case 'UP': return 'rotate(-90deg)';
-      case 'DOWN': return 'rotate(90deg)';
-      case 'LEFT': return 'rotate(180deg)';
-      case 'RIGHT': return 'rotate(0deg)';
-      default: return 'rotate(0deg)';
+  const transformStyle = useMemo(() => {
+    if (activeModel === 'labadze') {
+      switch (heading) {
+        case 'LEFT': return 'scaleX(-1)'; 
+        case 'RIGHT': return 'scaleX(1)'; 
+        case 'UP': return 'scaleX(1)';    
+        case 'DOWN': return 'scaleX(1)';  
+        default: return 'scaleX(1)';
+      }
+    } else {
+      switch (heading) {
+        case 'UP': return 'rotate(-90deg)';
+        case 'DOWN': return 'rotate(90deg)';
+        case 'LEFT': return 'rotate(180deg)';
+        case 'RIGHT': return 'rotate(0deg)';
+        default: return 'rotate(0deg)';
+      }
     }
-  }, [heading]);
+  }, [heading, activeModel]);
 
   return (
     <div 
       style={{ 
         width: size, 
         height: size,
-        transform: rotationTransform,
+        transform: transformStyle,
         transformOrigin: 'center center'
       }} 
       className="relative z-20 transition-transform duration-150 ease-linear"
     >
-      <svg viewBox="0 0 100 100" className="w-full h-full">
-        <path fill="#FFD700">
-          <animate 
-            attributeName="d" 
-            values="
-              M50 50 L100 50 A50 50 0 1 1 100 49.9 Z;
-              M50 50 L85 85 A50 50 0 1 1 85 15 Z;
-              M50 50 L100 50 A50 50 0 1 1 100 49.9 Z
-            "
-            dur={duration}
-            repeatCount="indefinite"
-            keyTimes="0; 0.5; 1"
-            calcMode="discrete" 
-          />
-        </path>
-      </svg>
+      {activeModel === 'labadze' ? (
+        <Labadze2D size={size} />
+      ) : (
+        <ClassicPacman2D/>
+      )}
     </div>
   );
 };

--- a/src/pages/Showcases/PacmanShowcase.tsx
+++ b/src/pages/Showcases/PacmanShowcase.tsx
@@ -84,7 +84,7 @@ export const PacmanShowcase = () => {
   ) : (
     <div className="flex items-center justify-center h-full">
          <div className="z-10 transform scale-150 p-12 bg-white/5 rounded-3xl backdrop-blur-xl border border-white/10 shadow-2xl">
-            <Pacman2D size={150} />
+            <Pacman2D size={150} heading="RIGHT" forceModel={selectedModel}/>
          </div>
     </div>
   );


### PR DESCRIPTION
Introduce a new ClassicPacman2D SVG component (simple animated mouth) and overhaul Labadze2D into a richer, standalone SVG avatar with gradients, clipping and animated elements. Update Pacman2D to read the active model from theme (useTheme) or accept a forceModel prop, apply different transform logic for the Labadze model, and render either Labadze2D or ClassicPacman2D accordingly. Adjust PacmanShowcase to pass the selectedModel via forceModel. Minor prop and layout changes: Labadze2D now defaults size and removes heading/rotation logic in favor of the parent transform handling.