### PR TITLE
Lazy-load routes, add Loader, tweak 3D canvas

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,14 @@
+import { Suspense, lazy } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { ThemeProvider } from './context/ThemeProvider'; 
 import { GameProvider } from './context/GameProvider';   
 import { Header } from './components/layout/Header';
-import { GamePage } from './pages/GamePage';
-import { SettingsPage } from './pages/SettingsPage';
-import { GhostShowcase } from './pages/Showcases/GhostShowcase';
-import { FoodShowcase } from './pages/Showcases/FoodShowcase'; 
-import { PacmanShowcase } from './pages/Showcases/PacmanShowcase';
+import { Loader } from './components/UI/Loader'; 
+const GamePage = lazy(() => import('./pages/GamePage').then(m => ({ default: m.GamePage })));
+const SettingsPage = lazy(() => import('./pages/SettingsPage').then(m => ({ default: m.SettingsPage })));
+const GhostShowcase = lazy(() => import('./pages/Showcases/GhostShowcase').then(m => ({ default: m.GhostShowcase })));
+const FoodShowcase = lazy(() => import('./pages/Showcases/FoodShowcase').then(m => ({ default: m.FoodShowcase })));
+const PacmanShowcase = lazy(() => import('./pages/Showcases/PacmanShowcase').then(m => ({ default: m.PacmanShowcase })));
 
 function App() {
   return (
@@ -16,13 +18,15 @@ function App() {
           <div className="min-h-screen bg-bg-main text-text-main font-poppins transition-colors duration-300">
             <Header />
             <main className="w-full pt-[calc(4rem+env(safe-area-inset-top))]">
-              <Routes>
-                <Route path="/" element={<GamePage />} />
-                <Route path="/settings" element={<SettingsPage />} />
-                <Route path="/ghost-lab" element={<GhostShowcase />} />
-                <Route path="/food-lab" element={<FoodShowcase />} />
-                <Route path="/pacman-lab" element={<PacmanShowcase />} />
-              </Routes>
+              <Suspense fallback={<Loader />}>
+                <Routes>
+                  <Route path="/" element={<GamePage />} />
+                  <Route path="/settings" element={<SettingsPage />} />
+                  <Route path="/ghost-lab" element={<GhostShowcase />} />
+                  <Route path="/food-lab" element={<FoodShowcase />} />
+                  <Route path="/pacman-lab" element={<PacmanShowcase />} />
+                </Routes>
+              </Suspense>
             </main>
           </div>
         </BrowserRouter>

--- a/src/components/UI/Loader.tsx
+++ b/src/components/UI/Loader.tsx
@@ -1,0 +1,13 @@
+export const Loader = () => {
+  return (
+    <div className="flex flex-col h-[50vh] w-full items-center justify-center gap-4">
+      <div className="relative w-12 h-12">
+        <div className="absolute inset-0 rounded-full border-4 border-yellow-400 border-r-transparent animate-spin"></div>
+        <div className="absolute inset-2 rounded-full border-4 border-blue-500 border-l-transparent animate-spin direction-reverse"></div>
+      </div>
+      <span className="text-yellow-400 font-bold tracking-widest animate-pulse text-sm">
+        LOADING...
+      </span>
+    </div>
+  );
+};

--- a/src/components/UI/ShowcaseCanvas.tsx
+++ b/src/components/UI/ShowcaseCanvas.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { Suspense, type ReactNode } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
 
@@ -20,13 +20,15 @@ export const ShowcaseCanvas = ({
   return (
     <Canvas camera={{ position: cameraPosition, fov: 50 }}>
       <OrbitControls 
-        enablePan={false} 
+        enablePan={true} 
+        enableZoom={true}
+        enableRotate={true}
         autoRotate 
         autoRotateSpeed={1.5}
-        minPolarAngle={Math.PI / 4} 
-        maxPolarAngle={Math.PI / 2} 
-        minDistance={2}
-        maxDistance={10}
+        minDistance={0.5} 
+        maxDistance={30}
+        minPolarAngle={0} 
+        maxPolarAngle={Math.PI / 2 + 0.1} 
       />
 
       {/* განათება */}
@@ -34,16 +36,19 @@ export const ShowcaseCanvas = ({
       <pointLight position={[10, 10, 10]} intensity={1} />
       <pointLight position={[-10, -5, -5]} intensity={0.5} color={isDark ? "blue" : "orange"} />
 
-      {/* მოდელის კონტეინერი */}
-      <group scale={[scale, scale, scale]} position={position}>
-        {children}
-      </group>
+      <Suspense fallback={null}>
+        <group scale={scale} position={position}>
+          {children}
+        </group>
+      </Suspense>
 
-      {/* იატაკის ბადე */}
       <gridHelper 
-        args={[20, 20, isDark ? '#333' : '#ddd', isDark ? '#111' : '#f0f0f0']} 
-        position={[0, -1, 0]} 
+        args={[20, 20, isDark ? '#ffffff' : '#000000', isDark ? '#ffffff' : '#000000']} 
+        position={[0, -1.2, 0]} 
+        material-opacity={isDark ? 0.2 : 0.1} 
+        material-transparent={true}
       />
+
     </Canvas>
   );
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,21 +41,14 @@ export default defineConfig({
     })
   ],
   build: {
-    chunkSizeWarningLimit: 1600, 
     rollupOptions: {
       output: {
-        manualChunks(id) {
-          if (id.includes('node_modules')) {
-            return 'vendor';
-          }
+        manualChunks: {
+          'vendor-react': ['react', 'react-dom', 'react-router-dom'],
+          'vendor-three': ['three', '@react-three/fiber', '@react-three/drei'],
+          'vendor-i18n': ['i18next', 'react-i18next', 'i18next-browser-languagedetector', 'i18next-http-backend']
         }
       }
     }
-  },
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: './src/tests/setup.ts',
-    css: false, 
   }
 })


### PR DESCRIPTION
Introduce route-level code-splitting by replacing direct page imports with React.lazy and wrapping Routes in Suspense using a new Loader component for a loading fallback. Add a simple Loader UI component. Update ShowcaseCanvas to support async model loading (wrap group in Suspense), enable pan/zoom/rotate on OrbitControls, relax distance/angle limits, and adjust grid helper appearance/position and group scaling. Adjust Vite rollup output to explicit vendor manualChunks (split react/three/i18n bundles) and remove previous chunkSizeWarning/test config entries to streamline build output.