### PR TITLE
Add debounce util and debounce resize handlers

### DIFF
--- a/src/components/Game/2D/Board.tsx
+++ b/src/components/Game/2D/Board.tsx
@@ -7,6 +7,7 @@ import { Ghost2D } from './Ghost2D';
 import { Food2D } from '../2D/Food2D';
 import { Pacman2D } from '../../Game/Player/Pacman2D';
 import type { PlayerHeading } from '../../../hooks/usePlayerHeading'; 
+import { debounce } from '../../../utils/debounce';
 
 const MAP_COLS = 19;
 const MAP_ROWS = 22;
@@ -39,9 +40,13 @@ export const Board = ({ isMinimap = false, heading, parentWidth = 0, parentHeigh
     });
   }, [subscribeToPositions, playerPosRef, ghostsPosRef]);
 
-  useEffect(() => {
+ useEffect(() => {
     if (!isMinimap) return;
-    const handleResize = () => setWindowWidth(window.innerWidth);
+
+    const handleResize = debounce(() => {
+        setWindowWidth(window.innerWidth);
+    }, 150);
+    
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, [isMinimap]);

--- a/src/hooks/useIsMobile.ts
+++ b/src/hooks/useIsMobile.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { debounce } from '../utils/debounce'; 
 
 export const useIsMobile = () => {
   const [isMobile, setIsMobile] = useState(() => {
@@ -9,10 +10,10 @@ export const useIsMobile = () => {
   });
 
   useEffect(() => {
-    const handleResize = () => {
+    const handleResize = debounce(() => {
       const check = window.innerWidth < 768 || /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
       setIsMobile(check);
-    };
+    }, 150);
 
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,0 +1,11 @@
+export function debounce<Args extends unknown[]>(
+  func: (...args: Args) => void,
+  delay: number
+): (...args: Args) => void {
+  let timeoutId: ReturnType<typeof setTimeout>;
+
+  return function (...args: Args) {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => func(...args), delay);
+  };
+}


### PR DESCRIPTION
Introduce a reusable debounce utility (src/utils/debounce.ts) and apply it to window resize handlers in Board.tsx and useIsMobile.ts to limit frequent state updates. Resize callbacks are now debounced with a 150ms delay to reduce re-renders during rapid resizing.