### PR TITLE
Resume and control game audio playback

### DIFF
--- a/src/components/Game/3D/Food3D.tsx
+++ b/src/components/Game/3D/Food3D.tsx
@@ -85,7 +85,6 @@ export const Food3D = ({ consumableVariant, themeOverride }: Food3DProps) => {
              url={soundFile} 
              distance={3}
              loop={false}
-             autoplay
            />
         )}
     </group>

--- a/src/components/Game/3D/Ghost3D.tsx
+++ b/src/components/Game/3D/Ghost3D.tsx
@@ -68,6 +68,16 @@ export const Ghost3D = ({ index, color }: Ghost3DProps) => {
     }
   }, [sfxVolume, isSfxEnabled]);
 
+  useEffect(() => {
+    if (audioRef.current) {
+      if (gameStatus === 'playing' && !audioRef.current.isPlaying) {
+         audioRef.current.play();
+      } else if (gameStatus !== 'playing' && audioRef.current.isPlaying) {
+         audioRef.current.pause();
+      }
+    }
+  }, [gameStatus]);
+
   useFrame((stateThree, delta) => {
     if (!groupRef.current) return;
     
@@ -133,6 +143,7 @@ export const Ghost3D = ({ index, color }: Ghost3DProps) => {
         groupRef.current.position.y = 0.5; 
     }
   });
+  
 
   const displayColor = visualState === 'SCARED' ? '#0000FF' : color;
 
@@ -187,7 +198,6 @@ export const Ghost3D = ({ index, color }: Ghost3DProps) => {
           url={sirenUrl} 
           distance={1} 
           loop
-          autoplay
         />
       )}
     </group>

--- a/src/context/GameProvider.tsx
+++ b/src/context/GameProvider.tsx
@@ -6,6 +6,7 @@ import { calculateGhostNextMove } from '../utils/ghostLogic';
 import { useTheme } from './ThemeContext';
 import { useGameAudio } from '../hooks/useGameAudio'; 
 import { checkCollision, checkFoodEaten, checkBonusEaten } from '../utils/physics';
+import * as THREE from 'three';
 
 const MAX_LIVES = 3;
 
@@ -84,6 +85,13 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
   const playerDirRef = useRef<Position>({ x: 1, z: 0 }); 
   const layoutRef = useRef(layout);
 
+  const resumeAudioContext = () => {
+    const audioCtx = THREE.AudioContext.getContext();
+    if (audioCtx && audioCtx.state === 'suspended') {
+      audioCtx.resume();
+    }
+  };
+
   useEffect(() => { layoutRef.current = layout; }, [layout]);
 
   useEffect(() => {
@@ -140,6 +148,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
   }, [level, notifyListeners]); 
 
   const startGame = () => {
+    resumeAudioContext();
     if (gameStatus === 'idle' || gameStatus === 'gameover' || gameStatus === 'won') {
         restartGame();
     } else {
@@ -149,6 +158,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
   };
 
   const startRound = () => {
+    resumeAudioContext();
     setGameStatus('playing');
   };
 
@@ -156,6 +166,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
   const resumeGame = () => { if (gameStatus === 'paused') setGameStatus('playing'); };
   
   const restartGame = () => {
+    resumeAudioContext();
     if (powerModeTimerRef.current) clearTimeout(powerModeTimerRef.current);
     if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
     if (bonusTimerRef.current) clearTimeout(bonusTimerRef.current);


### PR DESCRIPTION
Stop using autoplay on in-scene audio and add programmatic audio control. Removed autoplay props from Food3D and Ghost3D audio components, and added a useEffect in Ghost3D to play/pause its audio based on gameStatus. In GameProvider, import THREE and add resumeAudioContext() to resume a suspended AudioContext; call it from startGame, startRound and restartGame so audio will reliably start after user interaction.