### PR TITLE
Keep layoutRef in sync and use in food check

### DIFF
--- a/src/context/GameProvider.tsx
+++ b/src/context/GameProvider.tsx
@@ -178,6 +178,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
     notifyListeners();
 
     setLayout(freshData.initialLayout);
+    layoutRef.current = freshData.initialLayout;
     setRemainingFood(freshData.foodCount); 
     setDotsEaten(0); 
     setScore(0);
@@ -208,6 +209,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
       notifyListeners();
 
       setLayout(freshData.initialLayout);
+      layoutRef.current = freshData.initialLayout;
       setRemainingFood(freshData.foodCount);
       setDotsEaten(0);
       
@@ -295,8 +297,10 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
     playerPosRef.current = newPos;
     notifyListeners();
 
-    const foodResult = checkFoodEaten(newPos, layout);
+    const foodResult = checkFoodEaten(newPos, layoutRef.current);
+
     if (foodResult.hasEaten) {
+      layoutRef.current = foodResult.newLayout;
       const newDots = dotsEaten + 1;
       setDotsEaten(newDots); 
       setScore(s => s + foodResult.points);


### PR DESCRIPTION
Set layoutRef.current whenever initialLayout is applied so the ref mirrors state updates. Use layoutRef.current when calling checkFoodEaten to avoid stale-state reads, and update layoutRef.current with the returned newLayout when food is eaten. These changes ensure the ref stays consistent with state and prevent race/consistency issues during movement and food-eating logic.