### PR TITLE
Optimize GL settings and DPR for mobile

### DIFF
--- a/src/components/Game/3D/Board3D.tsx
+++ b/src/components/Game/3D/Board3D.tsx
@@ -43,8 +43,13 @@ export const Board3D = ({ heading }: Board3DProps) => {
         shadows={!isMobile} 
         camera={{ fov: 60, near: 0.001 }} 
         className="touch-none block"
-        dpr={isMobile ? [1, 1.5] : [1, 2]} 
+        dpr={isMobile ? 1 : [1, 2]} 
         frameloop="always"
+        gl={{
+          antialias: !isMobile,
+          powerPreference: "high-performance",
+          precision: isMobile ? "mediump" : "highp"
+        }}
       >
         <Suspense fallback={null}>
           <color attach="background" args={['#050505']} />


### PR DESCRIPTION
Simplify DPR for mobile to a single value and add explicit WebGL context options. Disable antialias on mobile, set powerPreference to high-performance, and use lower precision on mobile (mediump) vs highp on desktop to improve performance and rendering consistency across devices.