### PR TITLE
Precompute 3D food geometries & refine ghost logic

### DIFF
--- a/src/components/Game/3D/Board3D.tsx
+++ b/src/components/Game/3D/Board3D.tsx
@@ -69,11 +69,13 @@ export const Board3D = ({ heading }: Board3DProps) => {
           <InstancedFood layout={layout} />
 
           {activeBonus && (
-             <group position={[activeBonus.x, 0.5, activeBonus.z]}>
-                 {activeBonus.type === 'CHERRY' && <Food3D consumableVariant="cherry" />}
-                 {activeBonus.type === 'STRAWBERRY' && <Food3D consumableVariant="strawberry" />}
-                 {activeBonus.type === 'EXTRA_LIFE' && <Food3D consumableVariant="life" />}
-             </group>
+             <Suspense fallback={null}>
+                 <group position={[activeBonus.x, 0.5, activeBonus.z]}>
+                     {activeBonus.type === 'CHERRY' && <Food3D consumableVariant="cherry" />}
+                     {activeBonus.type === 'STRAWBERRY' && <Food3D consumableVariant="strawberry" />}
+                     {activeBonus.type === 'EXTRA_LIFE' && <Food3D consumableVariant="life" />}
+                 </group>
+             </Suspense>
           )}
 
           {/* Ghosts */}

--- a/src/components/Game/3D/Food/Cherry3D.tsx
+++ b/src/components/Game/3D/Food/Cherry3D.tsx
@@ -1,33 +1,24 @@
-export const Cherry3D = () => {
-  const cherryFleshMaterial = { color: "#be123c", roughness: 0.1, metalness: 0.4 }; 
-  const stemMaterial = { color: "#a16207", roughness: 0.8 };
+import * as THREE from 'three';
 
+const cherryGeo = new THREE.SphereGeometry(0.15, 32, 32);
+const stemGeo = new THREE.CylinderGeometry(0.008, 0.008, 0.6);
+const topGeo = new THREE.SphereGeometry(0.018);
+
+const cherryFleshMaterial = new THREE.MeshStandardMaterial({ color: "#be123c", roughness: 0.1, metalness: 0.4 }); 
+const stemMaterial = new THREE.MeshStandardMaterial({ color: "#a16207", roughness: 0.8 });
+
+export const Cherry3D = () => {
   return (
     <group position={[0, 0.1, 0]}>
       <group position={[-0.16, -0.2, 0]} rotation={[0, 0, 0.2]}>
-        <mesh>
-          <sphereGeometry args={[0.15, 32, 32]} />
-          <meshStandardMaterial {...cherryFleshMaterial} />
-        </mesh>
+        <mesh geometry={cherryGeo} material={cherryFleshMaterial} />
       </group>
       <group position={[0.16, -0.2, 0]} rotation={[0, 0, -0.2]}>
-        <mesh>
-          <sphereGeometry args={[0.15, 32, 32]} />
-          <meshStandardMaterial {...cherryFleshMaterial} />
-        </mesh>
+        <mesh geometry={cherryGeo} material={cherryFleshMaterial} />
       </group>
-      <mesh position={[-0.08, 0.08, 0]} rotation={[0, 0, -0.3]}>
-        <cylinderGeometry args={[0.008, 0.008, 0.6]} />
-        <meshStandardMaterial {...stemMaterial} />
-      </mesh>
-      <mesh position={[0.08, 0.08, 0]} rotation={[0, 0, 0.3]}>
-        <cylinderGeometry args={[0.008, 0.008, 0.6]} />
-        <meshStandardMaterial {...stemMaterial} />
-      </mesh>
-      <mesh position={[0, 0.36, 0]}>
-        <sphereGeometry args={[0.018]} />
-        <meshStandardMaterial {...stemMaterial} />
-      </mesh>
+      <mesh position={[-0.08, 0.08, 0]} rotation={[0, 0, -0.3]} geometry={stemGeo} material={stemMaterial} />
+      <mesh position={[0.08, 0.08, 0]} rotation={[0, 0, 0.3]} geometry={stemGeo} material={stemMaterial} />
+      <mesh position={[0, 0.36, 0]} geometry={topGeo} material={stemMaterial} />
     </group>
   );
 };

--- a/src/components/Game/3D/Food/Kebab.tsx
+++ b/src/components/Game/3D/Food/Kebab.tsx
@@ -1,9 +1,45 @@
-import { useMemo, useRef, useLayoutEffect } from 'react';
 import * as THREE from 'three';
+import { useRef, useLayoutEffect } from 'react';
+
+const lavashGeo = (() => {
+  const geo = new THREE.CylinderGeometry(0.13, 0.13, 0.75, 16, 8, true);
+  const positions = geo.attributes.position;
+  const v = new THREE.Vector3();
+  const colors = new Float32Array(positions.count * 3);
+  const tempColor = new THREE.Color();
+  const doughColor = new THREE.Color("#FFF8DC"); 
+  const burnColor = new THREE.Color("#8B4513"); 
+
+  for (let i = 0; i < positions.count; i++) {
+    v.fromBufferAttribute(positions, i);
+    const crumple = Math.sin(v.y * 30 + v.x * 20) * 0.004; 
+    v.addScaledVector(v.clone().normalize(), crumple);
+    positions.setXYZ(i, v.x, v.y, v.z);
+
+    let noise = Math.sin(v.x * 15 + v.z * 15) * Math.sin(v.y * 25);
+    noise += Math.sin(i * 0.9) * 0.3; 
+    const burnFactor = Math.max(0, (noise - 0.4) * 3);
+    tempColor.copy(doughColor).lerp(burnColor, Math.min(1, burnFactor));
+
+    colors[i * 3] = tempColor.r;
+    colors[i * 3 + 1] = tempColor.g;
+    colors[i * 3 + 2] = tempColor.b;
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+  geo.computeVertexNormals();
+  return geo;
+})();
+
+const meatGeo = new THREE.CapsuleGeometry(0.11, 0.92, 4, 8);
+const meatMat = new THREE.MeshPhysicalMaterial({
+  color: "#771313", roughness: 0.65, metalness: 0.0, reflectivity: 0.5    
+});
+const lavashMat = new THREE.MeshStandardMaterial({
+  vertexColors: true, side: THREE.DoubleSide, roughness: 1, metalness: 0
+});
 
 export const Kebab = () => {
   const groupRef = useRef<THREE.Group>(null);
-
   useLayoutEffect(() => {
     if (groupRef.current) {
       groupRef.current.rotation.set(
@@ -14,64 +50,10 @@ export const Kebab = () => {
     }
   }, []);
 
-  const lavashGeometry = useMemo(() => {
-    const geo = new THREE.CylinderGeometry(0.13, 0.13, 0.75, 16, 8, true);
-    
-    const positions = geo.attributes.position;
-    const v = new THREE.Vector3();
-    const colors = new Float32Array(positions.count * 3);
-    const tempColor = new THREE.Color();
-
-    const doughColor = new THREE.Color("#FFF8DC"); 
-    const burnColor = new THREE.Color("#8B4513"); 
-
-    for (let i = 0; i < positions.count; i++) {
-      v.fromBufferAttribute(positions, i);
-
-      const crumple = Math.sin(v.y * 30 + v.x * 20) * 0.004; 
-      v.addScaledVector(v.clone().normalize(), crumple);
-      positions.setXYZ(i, v.x, v.y, v.z);
-
-      let noise = Math.sin(v.x * 15 + v.z * 15) * Math.sin(v.y * 25);
-      noise += Math.sin(i * 0.9) * 0.3; 
-
-      const burnFactor = Math.max(0, (noise - 0.4) * 3);
-      tempColor.copy(doughColor).lerp(burnColor, Math.min(1, burnFactor));
-
-      colors[i * 3] = tempColor.r;
-      colors[i * 3 + 1] = tempColor.g;
-      colors[i * 3 + 2] = tempColor.b;
-    }
-
-    geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
-    geo.computeVertexNormals();
-    return geo;
-  }, []);
-
   return (
     <group ref={groupRef}>
-      
-      {/* ხორცი */}
-      <mesh position={[0, 0, 0]}>
-        <capsuleGeometry args={[0.11, 0.92, 4, 8]} />
-        <meshPhysicalMaterial
-          color="#771313"   
-          roughness={0.65}     
-          metalness={0.0}       
-          reflectivity={0.5}    
-        />
-      </mesh>
-
-      {/* ლავაში */}
-      <mesh geometry={lavashGeometry}>
-        <meshStandardMaterial 
-          vertexColors={true} 
-          side={THREE.DoubleSide} 
-          roughness={1} 
-          metalness={0}
-        />
-      </mesh>
-
+      <mesh geometry={meatGeo} material={meatMat} />
+      <mesh geometry={lavashGeo} material={lavashMat} />
     </group>
   );
 };

--- a/src/components/Game/3D/Food/Khachapuri.tsx
+++ b/src/components/Game/3D/Food/Khachapuri.tsx
@@ -1,151 +1,98 @@
-import { useMemo, useRef, useLayoutEffect } from 'react';
 import * as THREE from 'three';
 
+const doughMat = new THREE.MeshStandardMaterial({
+  color: "#dca560", roughness: 0.85, metalness: 0.0,
+  flatShading: false, vertexColors: true, side: THREE.DoubleSide,
+});
+const cheeseMat = new THREE.MeshStandardMaterial({
+  color: "#ffc400", roughness: 0.3, metalness: 0.1,
+  emissive: "#ffab00", emissiveIntensity: 0.1, side: THREE.DoubleSide,
+});
+const yolkMat = new THREE.MeshStandardMaterial({
+  color: "#f1964f", roughness: 0.1, metalness: 0.0,
+});
+const butterMat = new THREE.MeshStandardMaterial({
+  color: "#fffacd", roughness: 0.3, opacity: 0.9,
+  transparent: true, depthWrite: false,
+});
+
+const crustRadius = 0.18; 
+const curve = new THREE.CatmullRomCurve3([
+  new THREE.Vector3(-1.2, 0, 0), new THREE.Vector3(-0.6, 0, 0.55),
+  new THREE.Vector3(0.6, 0, 0.55), new THREE.Vector3(1.2, 0, 0),
+  new THREE.Vector3(0.6, 0, -0.55), new THREE.Vector3(-0.6, 0, -0.55),
+], true, 'catmullrom', 0.4);
+
+const cheeseShape = new THREE.Shape();
+cheeseShape.moveTo(-1.2, 0);
+cheeseShape.bezierCurveTo(-0.6, 0.65, 0.6, 0.65, 1.2, 0);
+cheeseShape.bezierCurveTo(0.6, -0.65, -0.6, -0.65, -1.2, 0);
+
+const crustGeo = new THREE.TubeGeometry(curve, 32, crustRadius, 16, true);
+const leftTipGeo = new THREE.CylinderGeometry(0.05, crustRadius * 0.98, 0.3, 32, 32);
+const rightTipGeo = new THREE.CylinderGeometry(0.05, crustRadius * 0.98, 0.3, 32, 32);
+const cheeseGeo = new THREE.ShapeGeometry(cheeseShape);
+const yolkGeo = new THREE.SphereGeometry(0.18, 32, 16, 0, Math.PI * 2, 0, Math.PI / 1.8);
+const butterGeo = new THREE.BoxGeometry(0.12, 0.08, 0.12);
+
+const applyDoughTexture = (geo: THREE.BufferGeometry, isTip: boolean = false) => {
+  const count = geo.attributes.position.count;
+  geo.setAttribute('color', new THREE.BufferAttribute(new Float32Array(count * 3), 3));
+  const posAttribute = geo.attributes.position;
+  const colorAttribute = geo.attributes.color;
+  const vertex = new THREE.Vector3();
+  const baseColor = new THREE.Color("#dca560");
+  const burntColor = new THREE.Color("#8a5020");
+  const cylinderHeight = 0.3; 
+  const halfHeight = cylinderHeight / 2; 
+
+  for (let i = 0; i < count; i++) {
+      vertex.fromBufferAttribute(posAttribute, i);
+      if (isTip) {
+          let t = (vertex.y + halfHeight) / cylinderHeight;
+          t = Math.max(0, Math.min(1, t)); 
+          const roundingScale = Math.sqrt(1.0 - t * t);
+          vertex.x *= roundingScale; vertex.z *= roundingScale;
+          const normalizedY = (vertex.y + halfHeight); 
+          const twistAmount = normalizedY * 6.0; 
+          const cosT = Math.cos(twistAmount);
+          const sinT = Math.sin(twistAmount);
+          const x = vertex.x * cosT - vertex.z * sinT;
+          const z = vertex.x * sinT + vertex.z * cosT;
+          vertex.x = x; vertex.z = z;
+      }
+      const noise = Math.sin(vertex.x * 12) * Math.cos(vertex.y * 12) * Math.sin(vertex.z * 12 + i * 0.1);
+      let displacement = noise * 0.025; 
+      if (isTip && vertex.y > 0.1) displacement *= 0.3;
+      vertex.addScaledVector(vertex.clone().normalize(), displacement); 
+      posAttribute.setXYZ(i, vertex.x, vertex.y, vertex.z);
+      const mixFactor = (noise + 1) / 2; 
+      const finalColor = baseColor.clone().lerp(burntColor, Math.pow(mixFactor, 4) * 0.9);
+      colorAttribute.setXYZ(i, finalColor.r, finalColor.g, finalColor.b);
+  }
+  geo.computeVertexNormals();
+};
+
+applyDoughTexture(crustGeo, false);
+applyDoughTexture(leftTipGeo, true);
+applyDoughTexture(rightTipGeo, true);
+
 export const Khachapuri = () => {
-  const { materials, shapes } = useMemo(() => {
-    const doughMat = new THREE.MeshStandardMaterial({
-      color: "#dca560",
-      roughness: 0.85,   
-      metalness: 0.0,
-      flatShading: false, 
-      vertexColors: true, 
-      side: THREE.DoubleSide,
-    });
-
-    const cheeseMat = new THREE.MeshStandardMaterial({
-      color: "#ffc400", 
-      roughness: 0.3,
-      metalness: 0.1,
-      emissive: "#ffab00",
-      emissiveIntensity: 0.1,
-      side: THREE.DoubleSide,
-    });
-
-    const yolkMat = new THREE.MeshStandardMaterial({
-      color: "#f1964f",
-      roughness: 0.1,
-      metalness: 0.0,
-    });
-
-    const butterMat = new THREE.MeshStandardMaterial({
-      color: "#fffacd",
-      roughness: 0.3,
-      opacity: 0.9,
-      transparent: true,
-      depthWrite: false,
-    });
-
-    const crustRadius = 0.18; 
-
-    const curve = new THREE.CatmullRomCurve3([
-      new THREE.Vector3(-1.2, 0, 0),
-      new THREE.Vector3(-0.6, 0, 0.55),
-      new THREE.Vector3(0.6, 0, 0.55), 
-      new THREE.Vector3(1.2, 0, 0),
-      new THREE.Vector3(0.6, 0, -0.55),
-      new THREE.Vector3(-0.6, 0, -0.55),
-    ], true, 'catmullrom', 0.4);
-
-    const cheeseShape = new THREE.Shape();
-    cheeseShape.moveTo(-1.2, 0);
-    cheeseShape.bezierCurveTo(-0.6, 0.65, 0.6, 0.65, 1.2, 0);
-    cheeseShape.bezierCurveTo(0.6, -0.65, -0.6, -0.65, -1.2, 0);
-
-    return { 
-      materials: { dough: doughMat, cheese: cheeseMat, yolk: yolkMat, butter: butterMat },
-      shapes: { curve, cheeseShape, crustRadius }
-    };
-  }, []);
-
-  const crustGeoRef = useRef<THREE.BufferGeometry>(null);
-  const leftTipRef = useRef<THREE.BufferGeometry>(null);
-  const rightTipRef = useRef<THREE.BufferGeometry>(null);
-  
-  const applyDoughTexture = (geo: THREE.BufferGeometry, isTip: boolean = false) => {
-    const count = geo.attributes.position.count;
-    if (!geo.attributes.color) geo.setAttribute('color', new THREE.BufferAttribute(new Float32Array(count * 3), 3));
-    const posAttribute = geo.attributes.position;
-    const colorAttribute = geo.attributes.color;
-    const vertex = new THREE.Vector3();
-    const baseColor = new THREE.Color("#dca560");
-    const burntColor = new THREE.Color("#8a5020");
-
-    const cylinderHeight = 0.3; 
-    const halfHeight = cylinderHeight / 2; 
-
-    for (let i = 0; i < count; i++) {
-        vertex.fromBufferAttribute(posAttribute, i);
-        
-        if (isTip) {
-            let t = (vertex.y + halfHeight) / cylinderHeight;
-            t = Math.max(0, Math.min(1, t)); 
-
-            const roundingScale = Math.sqrt(1.0 - t * t);
-
-            vertex.x *= roundingScale;
-            vertex.z *= roundingScale;
-
-            const normalizedY = (vertex.y + halfHeight); 
-            const twistAmount = normalizedY * 6.0; 
-            const cosT = Math.cos(twistAmount);
-            const sinT = Math.sin(twistAmount);
-            const x = vertex.x * cosT - vertex.z * sinT;
-            const z = vertex.x * sinT + vertex.z * cosT;
-            vertex.x = x; vertex.z = z;
-        }
-
-        const noise = Math.sin(vertex.x * 12) * Math.cos(vertex.y * 12) * Math.sin(vertex.z * 12 + i * 0.1);
-        let displacement = noise * 0.025; 
-        if (isTip && vertex.y > 0.1) displacement *= 0.3;
-
-        vertex.addScaledVector(vertex.clone().normalize(), displacement); 
-        posAttribute.setXYZ(i, vertex.x, vertex.y, vertex.z);
-
-        const mixFactor = (noise + 1) / 2; 
-        const finalColor = baseColor.clone().lerp(burntColor, Math.pow(mixFactor, 4) * 0.9);
-        colorAttribute.setXYZ(i, finalColor.r, finalColor.g, finalColor.b);
-    }
-    geo.computeVertexNormals();
-    posAttribute.needsUpdate = true;
-    colorAttribute.needsUpdate = true;
-  };
-
-  useLayoutEffect(() => {
-    if (crustGeoRef.current) applyDoughTexture(crustGeoRef.current, false);
-    if (leftTipRef.current) applyDoughTexture(leftTipRef.current, true);
-    if (rightTipRef.current) applyDoughTexture(rightTipRef.current, true);
-  }, []);
-
   return (
     <group rotation={[0, 0, 0]} scale={0.4}>
-      <mesh material={materials.dough}>
-        <tubeGeometry ref={crustGeoRef} args={[shapes.curve, 32, shapes.crustRadius, 16, true]} />
-      </mesh>
+      <mesh material={doughMat} geometry={crustGeo} />
 
-      <group position={[0, -shapes.crustRadius * 0.4, 0]}>
-        <mesh position={[0, -0.02, 0]} rotation={[Math.PI / 2, 0, 0]} material={materials.dough}>
-           <shapeGeometry args={[shapes.cheeseShape]} />
-        </mesh>
-        <mesh rotation={[Math.PI / 2, 0, 0]} scale={1.02} material={materials.cheese}>
-          <shapeGeometry args={[shapes.cheeseShape]} />
-        </mesh>
+      <group position={[0, -crustRadius * 0.4, 0]}>
+        <mesh position={[0, -0.02, 0]} rotation={[Math.PI / 2, 0, 0]} material={doughMat} geometry={cheeseGeo} />
+        <mesh rotation={[Math.PI / 2, 0, 0]} scale={1.02} material={cheeseMat} geometry={cheeseGeo} />
       </group>
 
-      <mesh position={[0, 0, 0]} material={materials.yolk}>
-        <sphereGeometry args={[0.18, 32, 16, 0, Math.PI * 2, 0, Math.PI / 1.8]} />
-      </mesh>
-      <mesh position={[0.35, 0.05, 0.1]} rotation={[0, 0.5, 0.2]} material={materials.butter}>
-        <boxGeometry args={[0.12, 0.08, 0.12]} />
-      </mesh>
+      <mesh position={[0, 0, 0]} material={yolkMat} geometry={yolkGeo} />
+      <mesh position={[0.35, 0.05, 0.1]} rotation={[0, 0.5, 0.2]} material={butterMat} geometry={butterGeo} />
 
       <group>
-        <mesh position={[-1.4, 0, 0]} rotation={[0, 0, Math.PI / 2]} material={materials.dough}>
-          <cylinderGeometry ref={leftTipRef} args={[0.05, shapes.crustRadius * 0.98, 0.3, 32, 32]} />
-        </mesh>
-        
-        <mesh position={[1.4, 0, 0]} rotation={[0, 0, -Math.PI / 2]} material={materials.dough}>
-          <cylinderGeometry ref={rightTipRef} args={[0.05, shapes.crustRadius * 0.98, 0.3, 32, 32]} />
-        </mesh>
+        <mesh position={[-1.4, 0, 0]} rotation={[0, 0, Math.PI / 2]} material={doughMat} geometry={leftTipGeo} />
+        <mesh position={[1.4, 0, 0]} rotation={[0, 0, -Math.PI / 2]} material={doughMat} geometry={rightTipGeo} />
       </group>
     </group>
   );

--- a/src/components/Game/3D/Food/Khinkali.tsx
+++ b/src/components/Game/3D/Food/Khinkali.tsx
@@ -1,94 +1,87 @@
-import { useMemo } from 'react';
 import * as THREE from 'three';
 
+const khinkaliGeometry = (() => {
+  const pleatCount = 19; 
+  const radialSegments = pleatCount * 16; 
+  const heightSegments = 30; 
+  
+  const totalHeight = 0.55;
+  const baseRadius = 0.15;   
+  const bellyRadius = 0.28;  
+  const neckRadius = 0.05;   
+  const headRadius = 0.045;  
+  const neckStart = 0.88; 
+
+  const positions = [];
+  const indices = [];
+
+  for (let y = 0; y <= heightSegments; y++) {
+    const v = y / heightSegments;
+    let currentRadius = 0;
+    let heightPos = v * totalHeight;
+
+    if (v < 0.2) {
+      const t = v / 0.2;
+      currentRadius = THREE.MathUtils.lerp(baseRadius, bellyRadius, Math.sin(t * Math.PI / 2));
+      heightPos = (1 - Math.cos(t * Math.PI / 2)) * (totalHeight * 0.2);
+    } else if (v < neckStart) {
+      const t = (v - 0.2) / (neckStart - 0.2);
+      currentRadius = THREE.MathUtils.lerp(bellyRadius, neckRadius, Math.pow(t, 1.2));
+    } else {
+      const t = (v - neckStart) / (1 - neckStart);
+      currentRadius = THREE.MathUtils.lerp(neckRadius, headRadius, t);
+    }
+
+    let pleatDepth = 0;
+    if (v > 0.05 && v < neckStart) {
+      const strengthT = (v - 0.05) / (neckStart - 0.05); 
+      pleatDepth = 0.04 * Math.sin(strengthT * Math.PI); 
+    } else {
+      pleatDepth = 0; 
+    }
+
+    for (let x = 0; x <= radialSegments; x++) {
+      const u = x / radialSegments;
+      const angle = u * Math.PI * 2;
+      const foldShape = Math.abs(Math.sin(angle * pleatCount / 2));
+      let offset = foldShape * pleatDepth;
+      const deepCrease = 1 - foldShape;
+      offset -= deepCrease * (pleatDepth * 2.0); 
+      let finalR = currentRadius + offset;
+      
+      if (v > 0.98) {
+          finalR *= (1 - (v - 0.98) / 0.02);
+      }
+      if (y === 0) finalR = 0;
+
+      const posX = Math.cos(angle) * finalR;
+      const posZ = Math.sin(angle) * finalR;
+      const posY = heightPos;
+      positions.push(posX, posY, posZ);
+    }
+  }
+
+  for (let y = 0; y < heightSegments; y++) {
+    for (let x = 0; x < radialSegments; x++) {
+      const a = y * (radialSegments + 1) + x;
+      const b = a + 1;
+      const c = (y + 1) * (radialSegments + 1) + x;
+      const d = c + 1;
+      indices.push(a, d, b, a, c, d);
+    }
+  }
+
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  geo.setIndex(indices);
+  geo.computeVertexNormals(); 
+  return geo;
+})();
+
 export const Khinkali = () => {
-  const geometry = useMemo(() => {
-    const pleatCount = 19; 
-    const radialSegments = pleatCount * 16; 
-    const heightSegments = 30; 
-    
-    const totalHeight = 0.55;
-    const baseRadius = 0.15;   
-    const bellyRadius = 0.28;  
-    const neckRadius = 0.05;   
-    const headRadius = 0.045;  
-    const neckStart = 0.88; 
-
-    const positions = [];
-    const indices = [];
-
-    for (let y = 0; y <= heightSegments; y++) {
-      const v = y / heightSegments;
-      
-      let currentRadius = 0;
-      let heightPos = v * totalHeight;
-
-      if (v < 0.2) {
-        const t = v / 0.2;
-        currentRadius = THREE.MathUtils.lerp(baseRadius, bellyRadius, Math.sin(t * Math.PI / 2));
-        heightPos = (1 - Math.cos(t * Math.PI / 2)) * (totalHeight * 0.2);
-      } else if (v < neckStart) {
-        const t = (v - 0.2) / (neckStart - 0.2);
-        currentRadius = THREE.MathUtils.lerp(bellyRadius, neckRadius, Math.pow(t, 1.2));
-      } else {
-        const t = (v - neckStart) / (1 - neckStart);
-        currentRadius = THREE.MathUtils.lerp(neckRadius, headRadius, t);
-      }
-
-      let pleatDepth = 0;
-      
-      if (v > 0.05 && v < neckStart) {
-        const strengthT = (v - 0.05) / (neckStart - 0.05); 
-        pleatDepth = 0.04 * Math.sin(strengthT * Math.PI); 
-      } else {
-        pleatDepth = 0; 
-      }
-
-      for (let x = 0; x <= radialSegments; x++) {
-        const u = x / radialSegments;
-        const angle = u * Math.PI * 2;
-
-        const foldShape = Math.abs(Math.sin(angle * pleatCount / 2));
-        
-        let offset = foldShape * pleatDepth;
-        const deepCrease = 1 - foldShape;
-        offset -= deepCrease * (pleatDepth * 2.0); 
-
-        let finalR = currentRadius + offset;
-        
-        if (v > 0.98) {
-            finalR *= (1 - (v - 0.98) / 0.02);
-        }
-        if (y === 0) finalR = 0;
-
-        const posX = Math.cos(angle) * finalR;
-        const posZ = Math.sin(angle) * finalR;
-        const posY = heightPos;
-
-        positions.push(posX, posY, posZ);
-      }
-    }
-
-    for (let y = 0; y < heightSegments; y++) {
-      for (let x = 0; x < radialSegments; x++) {
-        const a = y * (radialSegments + 1) + x;
-        const b = a + 1;
-        const c = (y + 1) * (radialSegments + 1) + x;
-        const d = c + 1;
-        indices.push(a, d, b, a, c, d);
-      }
-    }
-
-    const geo = new THREE.BufferGeometry();
-    geo.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
-    geo.setIndex(indices);
-    geo.computeVertexNormals(); 
-    return geo;
-  }, []);
-
   return (
     <group scale={1.0} position={[0, -0.27, 0]}>
-      <mesh geometry={geometry} castShadow receiveShadow>
+      <mesh geometry={khinkaliGeometry} castShadow receiveShadow>
         <meshStandardMaterial 
             color="#E8E2D5" 
             roughness={0.7} 

--- a/src/components/Game/3D/Food/Life3D.tsx
+++ b/src/components/Game/3D/Food/Life3D.tsx
@@ -1,32 +1,27 @@
-import { useMemo } from 'react';
-import { Shape, ExtrudeGeometry } from 'three';
+import * as THREE from 'three';
+
+const heartGeo = (() => {
+  const x = 0, y = 0;
+  const heartShape = new THREE.Shape();
+  heartShape.moveTo( x + 0.25, y + 0.25 );
+  heartShape.bezierCurveTo( x + 0.25, y + 0.25, x + 0.20, y, x, y );
+  heartShape.bezierCurveTo( x - 0.30, y, x - 0.30, y + 0.35, x - 0.30, y + 0.35 );
+  heartShape.bezierCurveTo( x - 0.30, y + 0.55, x - 0.10, y + 0.77, x + 0.25, y + 0.95 );
+  heartShape.bezierCurveTo( x + 0.60, y + 0.77, x + 0.80, y + 0.55, x + 0.80, y + 0.35 );
+  heartShape.bezierCurveTo( x + 0.80, y + 0.35, x + 0.80, y, x + 0.50, y );
+  heartShape.bezierCurveTo( x + 0.35, y, x + 0.25, y + 0.25, x + 0.25, y + 0.25 );
+  const extrudeSettings = { depth: 0.2, bevelEnabled: true, bevelSegments: 2, steps: 2, bevelSize: 0.05, bevelThickness: 0.05 };
+  return new THREE.ExtrudeGeometry( heartShape, extrudeSettings );
+})();
+
+const heartMat = new THREE.MeshStandardMaterial({
+  color: "#ec4899", emissive: "#be185d", emissiveIntensity: 0.5, roughness: 0.2, metalness: 0.3 
+});
 
 export const Life3D = () => {
-  const heartGeometry = useMemo(() => {
-    const x = 0, y = 0;
-    const heartShape = new Shape();
-    heartShape.moveTo( x + 0.25, y + 0.25 );
-    heartShape.bezierCurveTo( x + 0.25, y + 0.25, x + 0.20, y, x, y );
-    heartShape.bezierCurveTo( x - 0.30, y, x - 0.30, y + 0.35, x - 0.30, y + 0.35 );
-    heartShape.bezierCurveTo( x - 0.30, y + 0.55, x - 0.10, y + 0.77, x + 0.25, y + 0.95 );
-    heartShape.bezierCurveTo( x + 0.60, y + 0.77, x + 0.80, y + 0.55, x + 0.80, y + 0.35 );
-    heartShape.bezierCurveTo( x + 0.80, y + 0.35, x + 0.80, y, x + 0.50, y );
-    heartShape.bezierCurveTo( x + 0.35, y, x + 0.25, y + 0.25, x + 0.25, y + 0.25 );
-    const extrudeSettings = { depth: 0.2, bevelEnabled: true, bevelSegments: 2, steps: 2, bevelSize: 0.05, bevelThickness: 0.05 };
-    return new ExtrudeGeometry( heartShape, extrudeSettings );
-  }, []);
-
   return (
     <group scale={[0.2, 0.4, 0.4]} rotation={[Math.PI, 0, 0]} position={[0, 0.2, 0]}>
-      <mesh geometry={heartGeometry} position={[-0.25, -0.25, 0]}>
-        <meshStandardMaterial 
-          color="#ec4899" 
-          emissive="#be185d" 
-          emissiveIntensity={0.5} 
-          roughness={0.2} 
-          metalness={0.3} 
-        />
-      </mesh>
+      <mesh geometry={heartGeo} material={heartMat} position={[-0.25, -0.25, 0]} />
     </group>
   );
 };

--- a/src/components/Game/3D/Food/Mchadi.tsx
+++ b/src/components/Game/3D/Food/Mchadi.tsx
@@ -1,58 +1,49 @@
-import { useMemo, useRef, useLayoutEffect } from 'react';
 import * as THREE from 'three';
+import { useRef, useLayoutEffect } from 'react';
 
 const randomGrain = (x: number, y: number, z: number) => {
   return Math.abs(Math.sin(x * 12.9898 + y * 78.233 + z * 53.53) * 43758.5453) % 1;
 };
 
+const mchadiGeo = (() => {
+  const geo = new THREE.SphereGeometry(0.13, 16, 16);
+  const positions = geo.attributes.position;
+  const count = positions.count;
+  const vertex = new THREE.Vector3();
+  const colors = new Float32Array(count * 3);
+  const tempColor = new THREE.Color();
+  const doughColor = new THREE.Color("#FCEEB5"); 
+  const goldenColor = new THREE.Color("#E3B04B"); 
+  const burntColor = new THREE.Color("#A35622"); 
+
+  for (let i = 0; i < count; i++) {
+    vertex.fromBufferAttribute(positions, i);
+    const warp = Math.sin(vertex.x * 3) * Math.sin(vertex.z * 3) * 0.02;
+    const grain = randomGrain(vertex.x, vertex.y, vertex.z);
+    const surfaceNoise = grain * 0.008; 
+    vertex.addScaledVector(vertex.clone().normalize(), warp + surfaceNoise);
+    positions.setXYZ(i, vertex.x, vertex.y, vertex.z);
+
+    tempColor.copy(doughColor);
+    if (grain > 0.6) tempColor.lerp(goldenColor, 0.6);
+    if (grain > 0.85) tempColor.lerp(burntColor, 0.7);
+
+    colors[i * 3] = tempColor.r;
+    colors[i * 3 + 1] = tempColor.g;
+    colors[i * 3 + 2] = tempColor.b;
+  }
+  geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+  geo.computeVertexNormals();
+  return geo;
+})();
+
+const mchadiMat = new THREE.MeshStandardMaterial({
+  vertexColors: true, roughness: 1, metalness: 0.0,
+  emissive: "#8B4513", emissiveIntensity: 0.1
+});
+
 export const Mchadi = () => {
   const meshRef = useRef<THREE.Mesh>(null);
-
-  const geometry = useMemo(() => {
-    const geo = new THREE.SphereGeometry(0.13, 16, 16);
-    
-    const positions = geo.attributes.position;
-    const count = positions.count;
-    const vertex = new THREE.Vector3();
-    
-    const colors = new Float32Array(count * 3);
-    
-    const tempColor = new THREE.Color();
-    
-    const doughColor = new THREE.Color("#FCEEB5"); 
-    const goldenColor = new THREE.Color("#E3B04B"); 
-    const burntColor = new THREE.Color("#A35622"); 
-
-    for (let i = 0; i < count; i++) {
-      vertex.fromBufferAttribute(positions, i);
-
-      const warp = Math.sin(vertex.x * 3) * Math.sin(vertex.z * 3) * 0.02;
-
-      const grain = randomGrain(vertex.x, vertex.y, vertex.z);
-      const surfaceNoise = grain * 0.008; 
-
-      vertex.addScaledVector(vertex.clone().normalize(), warp + surfaceNoise);
-      positions.setXYZ(i, vertex.x, vertex.y, vertex.z);
-
-      tempColor.copy(doughColor);
-
-      if (grain > 0.6) {
-        tempColor.lerp(goldenColor, 0.6);
-      }
-      if (grain > 0.85) {
-        tempColor.lerp(burntColor, 0.7);
-      }
-
-      colors[i * 3] = tempColor.r;
-      colors[i * 3 + 1] = tempColor.g;
-      colors[i * 3 + 2] = tempColor.b;
-    }
-
-    geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
-    geo.computeVertexNormals();
-    
-    return geo;
-  }, []);
 
   useLayoutEffect(() => {
     if (meshRef.current) {
@@ -63,16 +54,9 @@ export const Mchadi = () => {
   return (
     <mesh 
       ref={meshRef}
-      geometry={geometry} 
+      geometry={mchadiGeo} 
+      material={mchadiMat}
       scale={[1.5, 0.55, 1.15]} 
-    >
-      <meshStandardMaterial
-        vertexColors={true}
-        roughness={1}
-        metalness={0.0}
-        emissive={"#8B4513"} 
-        emissiveIntensity={0.1}
-      />
-    </mesh>
+    />
   );
 };

--- a/src/components/Game/3D/Food/Strawberry3D.tsx
+++ b/src/components/Game/3D/Food/Strawberry3D.tsx
@@ -1,133 +1,92 @@
 import * as THREE from 'three';
-import { useMemo } from 'react';
 
 const applyStrawberryShape = (x: number, y: number, z: number, baseRadius: number) => {
   const normalizedY = y / baseRadius; 
-
   const finalY = y * 1.3;
   const taperScale = 0.95 + 0.25 * normalizedY - 0.15 * (normalizedY * normalizedY);
-
   const finalX = x * taperScale;
   const finalZ = z * taperScale;
-
   return new THREE.Vector3(finalX, finalY, finalZ);
 };
 
+const strawberryRed = "#b81200";
+const seedYellow = "#d4b33d";
+const leafGreen = "#1e5c22";
+const baseRadius = 0.25;
+
+const strawberryGeometry = (() => {
+  const geo = new THREE.SphereGeometry(baseRadius, 64, 64);
+  const pos = geo.attributes.position;
+  for (let i = 0; i < pos.count; i++) {
+    const v = applyStrawberryShape(pos.getX(i), pos.getY(i), pos.getZ(i), baseRadius);
+    pos.setXYZ(i, v.x, v.y, v.z);
+  }
+  geo.computeVertexNormals();
+  return geo;
+})();
+
+const seedsData = (() => {
+  const items = [];
+  const totalSeeds = 150; 
+  const goldenRatio = Math.PI * (Math.sqrt(5) - 1);
+  for (let i = 0; i < totalSeeds; i++) {
+    const yOffset = 1 - (i / (totalSeeds - 1)) * 2; 
+    const radiusAtY = Math.sqrt(1 - yOffset * yOffset);
+    const theta = goldenRatio * i;
+    const rawX = Math.cos(theta) * radiusAtY * baseRadius;
+    const rawY = yOffset * baseRadius;
+    const rawZ = Math.sin(theta) * radiusAtY * baseRadius;
+    const shapedPos = applyStrawberryShape(rawX, rawY, rawZ, baseRadius);
+
+    if (yOffset < 0.85 && yOffset > -0.9) {
+      const normalVector = new THREE.Vector3(shapedPos.x, shapedPos.y * 0.4, shapedPos.z).normalize();
+      shapedPos.add(normalVector.clone().multiplyScalar(0.006));
+      const quaternion = new THREE.Quaternion().setFromUnitVectors(
+        new THREE.Vector3(0, 1, 0), normalVector
+      );
+      const scaleMultiplier = Math.max(0.4, Math.sqrt(1 - yOffset * yOffset));
+      items.push({
+        position: [shapedPos.x, shapedPos.y, shapedPos.z] as [number, number, number],
+        quaternion, scale: scaleMultiplier
+      });
+    }
+  }
+  return items;
+})();
+
+const stemCurve = new THREE.CatmullRomCurve3([
+  new THREE.Vector3(0, 0, 0), new THREE.Vector3(0.02, 0.12, 0),
+  new THREE.Vector3(0.08, 0.25, 0), new THREE.Vector3(0.18, 0.38, -0.05)
+]);
+
+const leafGeometry = new THREE.TubeGeometry(stemCurve, 20, 0.012, 8, false);
+const smallLeafGeo = new THREE.SphereGeometry(0.1, 16, 16);
+const seedGeometry = new THREE.CylinderGeometry(0.0045, 0.004, 0.006, 6);
+
+const strawberryMat = new THREE.MeshPhysicalMaterial({ color: strawberryRed, roughness: 0.4, metalness: 0.1, clearcoat: 0.8, clearcoatRoughness: 0.2 });
+const seedMat = new THREE.MeshStandardMaterial({ color: seedYellow, roughness: 0.6 });
+const leafMat = new THREE.MeshStandardMaterial({ color: leafGreen, roughness: 0.7 });
+const smallLeafMat = new THREE.MeshStandardMaterial({ color: leafGreen, roughness: 0.8 });
+
 export const Strawberry3D = () => {
-  const strawberryRed = "#b81200";
-  const seedYellow = "#d4b33d";
-  const leafGreen = "#1e5c22";
-  const baseRadius = 0.25;
-
-  const strawberryGeometry = useMemo(() => {
-    const geo = new THREE.SphereGeometry(baseRadius, 64, 64);
-    const pos = geo.attributes.position;
-    
-    for (let i = 0; i < pos.count; i++) {
-      const v = applyStrawberryShape(pos.getX(i), pos.getY(i), pos.getZ(i), baseRadius);
-      pos.setXYZ(i, v.x, v.y, v.z);
-    }
-    geo.computeVertexNormals();
-    return geo;
-  }, []);
-
-  const seedsData = useMemo(() => {
-    const items = [];
-    const totalSeeds = 150; 
-    const goldenRatio = Math.PI * (Math.sqrt(5) - 1);
-
-    for (let i = 0; i < totalSeeds; i++) {
-      const yOffset = 1 - (i / (totalSeeds - 1)) * 2; 
-      const radiusAtY = Math.sqrt(1 - yOffset * yOffset);
-      const theta = goldenRatio * i;
-
-      const rawX = Math.cos(theta) * radiusAtY * baseRadius;
-      const rawY = yOffset * baseRadius;
-      const rawZ = Math.sin(theta) * radiusAtY * baseRadius;
-
-      const shapedPos = applyStrawberryShape(rawX, rawY, rawZ, baseRadius);
-
-      if (yOffset < 0.85 && yOffset > -0.9) {
-
-        const normalVector = new THREE.Vector3(shapedPos.x, shapedPos.y * 0.4, shapedPos.z).normalize();
-
-        shapedPos.add(normalVector.clone().multiplyScalar(0.006));
-
-        const quaternion = new THREE.Quaternion().setFromUnitVectors(
-          new THREE.Vector3(0, 1, 0),
-          normalVector
-        );
-
-        const scaleMultiplier = Math.max(0.4, Math.sqrt(1 - yOffset * yOffset));
-
-        items.push({
-          position: [shapedPos.x, shapedPos.y, shapedPos.z] as [number, number, number],
-          quaternion,
-          scale: scaleMultiplier
-        });
-      }
-    }
-    return items;
-  }, []);
-
-  // ღეროს მრუდი 
-  const stemCurve = useMemo(() => {
-    return new THREE.CatmullRomCurve3([
-      new THREE.Vector3(0, 0, 0),
-      new THREE.Vector3(0.02, 0.12, 0),
-      new THREE.Vector3(0.08, 0.25, 0),
-      new THREE.Vector3(0.18, 0.38, -0.05)
-    ]);
-  }, []);
-
   return (
     <group position={[0, -0.1, 0]}>
+      <mesh geometry={strawberryGeometry} material={strawberryMat} />
       
-      <mesh geometry={strawberryGeometry}>
-        <meshPhysicalMaterial 
-          color={strawberryRed} 
-          roughness={0.4} 
-          metalness={0.1}
-          clearcoat={0.8}  
-          clearcoatRoughness={0.2}
-        />
-      </mesh>
-
-      {/* თესლების დარენდერება */}
       <group>
         {seedsData.map((seed, index) => (
-          <mesh 
-            key={`seed-${index}`} 
-            position={seed.position} 
-            quaternion={seed.quaternion}
-            scale={[seed.scale, 1, seed.scale]} 
-          >
-            <cylinderGeometry args={[0.0045, 0.004, 0.006, 6]} />
-            <meshStandardMaterial 
-              color={seedYellow} 
-              roughness={0.6} 
-            />
-          </mesh>
+          <mesh key={`seed-${index}`} position={seed.position} quaternion={seed.quaternion} scale={[seed.scale, 1, seed.scale]} geometry={seedGeometry} material={seedMat} />
         ))}
       </group>
 
-      {/* ფოთლები და ყუნწი */}
       <group position={[0, 0.31, 0]} scale={[1.1, 1.1, 1.1]}>
-        <mesh>
-          <tubeGeometry args={[stemCurve, 20, 0.012, 8, false]} />
-          <meshStandardMaterial color={leafGreen} roughness={0.7} />
-        </mesh>
-
+        <mesh geometry={leafGeometry} material={leafMat} />
         {[0, 60, 120, 180, 240, 300].map((degreeAngle, index) => (
           <group key={index} rotation={[0, THREE.MathUtils.degToRad(degreeAngle), 0]}>
-            <mesh position={[0, 0.01, 0.07]} rotation={[0.5, 0, 0]} scale={[0.4, 0.1, 1.3]}>
-              <sphereGeometry args={[0.1, 16, 16]} />
-              <meshStandardMaterial color={leafGreen} roughness={0.8} />
-            </mesh>
+            <mesh position={[0, 0.01, 0.07]} rotation={[0.5, 0, 0]} scale={[0.4, 0.1, 1.3]} geometry={smallLeafGeo} material={smallLeafMat} />
           </group>
         ))}
       </group>
-      
     </group>
   );
 };

--- a/src/components/Game/3D/Food3D.tsx
+++ b/src/components/Game/3D/Food3D.tsx
@@ -3,6 +3,8 @@ import { useFrame } from '@react-three/fiber';
 import { Group, PositionalAudio as ThreePositionalAudio } from 'three'; 
 import { PositionalAudio } from '@react-three/drei';
 import { useTheme } from '../../../context/ThemeContext';
+import { useLoader } from '@react-three/fiber';
+import * as THREE from 'three';
 
 import { Dot3D } from '../3D/Food/Dot3D';
 import { PowerPellet3D } from '../3D/Food/PowerPellet3D';
@@ -14,6 +16,10 @@ import { Mchadi } from '../3D/Food/Mchadi';
 import { Kebab } from '../3D/Food/Kebab';
 import { Khinkali } from '../3D/Food/Khinkali';
 import { Khachapuri } from '../3D/Food/Khachapuri';
+
+useLoader.preload(THREE.AudioLoader, '/sounds/eat_fruit.wav');
+useLoader.preload(THREE.AudioLoader, '/sounds/kacebi/labadze_eat_fruit.mp3');
+useLoader.preload(THREE.AudioLoader, '/sounds/extra_life.wav');
 
 type ConsumableVariant = 'dot' | 'power' | 'cherry' | 'strawberry' | 'life';
 

--- a/src/components/Game/3D/Ghost3D.tsx
+++ b/src/components/Game/3D/Ghost3D.tsx
@@ -114,7 +114,11 @@ export const Ghost3D = ({ index, color }: Ghost3DProps) => {
     const currentPos = groupRef.current.position;
     const targetPos = new Vector3(ghost.x, 0.5, ghost.z);
     const speed = visualState === 'EATEN' ? 15.0 : 6.0; 
-    currentPos.lerp(targetPos, speed * delta);
+    if (currentPos.distanceTo(targetPos) > 2) {
+       currentPos.copy(targetPos);
+    } else {
+       currentPos.lerp(targetPos, speed * delta);
+    }
     
     // როტაციის გამოთვლა
     const dx = targetPos.x - currentPos.x;

--- a/src/utils/ghostLogic.ts
+++ b/src/utils/ghostLogic.ts
@@ -38,46 +38,50 @@ const isRedZone = (x: number, z: number, dir: Coordinate) => {
 };
 
 // --- BFS PATHFINDING (Used for Eyes returning home) ---
-const getNextStepBFS = (start: Coordinate, target: Coordinate, layout: number[][]): Coordinate => {
+const getNextStepBFS = (start: Coordinate, target: Coordinate, layout: number[][]): { nextPos: Coordinate, nextDir: Coordinate } => {
   const startX = Math.round(start.x);
   const startZ = Math.round(start.z);
   const targetX = Math.round(target.x);
   const targetZ = Math.round(target.z);
 
-  if (startX === targetX && startZ === targetZ) return start;
+  if (startX === targetX && startZ === targetZ) {
+      return { nextPos: start, nextDir: { x: 0, z: 0 } };
+  }
 
-  const queue: { x: number, z: number, firstStep: Coordinate | null }[] = [
-    { x: startX, z: startZ, firstStep: null }
+  const queue: { x: number, z: number, firstPos: Coordinate | null, firstDir: Coordinate | null }[] = [
+    { x: startX, z: startZ, firstPos: null, firstDir: null }
   ];
   const visited = new Set<string>();
   visited.add(`${startX},${startZ}`);
 
   while (queue.length > 0) {
-    const { x, z, firstStep } = queue.shift()!;
-    if (x === targetX && z === targetZ) return firstStep || { x: targetX, z: targetZ };
+    const { x, z, firstPos, firstDir } = queue.shift()!;
+    if (x === targetX && z === targetZ) {
+        return { nextPos: firstPos!, nextDir: firstDir! };
+    }
 
     for (const dir of DIRECTIONS) {
-      const nextX = x + dir.x;
+      let nextX = x + dir.x;
       const nextZ = z + dir.z;
-      const key = `${nextX},${nextZ}`;
-      
-      let isPassable = false;
-      if (nextZ === TUNNEL_ROW) isPassable = true;
-      else if (nextZ >= 0 && nextZ < layout.length && nextX >= 0 && nextX < layout[0].length) {
-          const t = layout[nextZ][nextX];
-          // Eyes ignore walls conceptually, but sticking to paths usually looks better in 3D
-          // For simplicity, eyes use standard pathing but ignore player collision
-          isPassable = t !== TileType.WALL; 
+
+      const stepPos = firstPos || { x: nextX, z: nextZ };
+      const stepDir = firstDir || dir;
+
+      if (nextZ === TUNNEL_ROW) {
+        if (nextX < 0) nextX = layout[0].length - 1;
+        else if (nextX >= layout[0].length) nextX = 0;
       }
+
+      const key = `${nextX},${nextZ}`;
+      const isPassable = !isWall(nextX, nextZ, layout, true);
 
       if (!visited.has(key) && isPassable) {
         visited.add(key);
-        const nextFirstStep = firstStep || { x: nextX, z: nextZ };
-        queue.push({ x: nextX, z: nextZ, firstStep: nextFirstStep });
+        queue.push({ x: nextX, z: nextZ, firstPos: stepPos, firstDir: stepDir });
       }
     }
   }
-  return { x: startX, z: startZ };
+  return { nextPos: start, nextDir: { x: 0, z: 0 } };
 };
 
 // --- TARGETING ---
@@ -113,7 +117,13 @@ const getBestMove = (current: Coordinate, currentDir: Coordinate, target: Coordi
     const nextZ = current.z + dir.z;
 
     if (!isWall(nextX, nextZ, layout, allowHouse)) {
-      const dist = getDistSq({ x: nextX, z: nextZ }, target);
+      let checkX = nextX;
+      if (nextZ === TUNNEL_ROW) {
+          if (checkX < 0) checkX = layout[0].length - 1;
+          else if (checkX >= layout[0].length) checkX = 0;
+      }
+      
+      const dist = getDistSq({ x: checkX, z: nextZ }, target);
       validMoves.push({ pos: { x: nextX, z: nextZ }, dir, dist });
     }
   }
@@ -173,18 +183,12 @@ export const calculateGhostNextMove = (
   const currentPos = { x: Math.round(ghost.x), z: Math.round(ghost.z) };
   
   // EATEN STATE (Eyes returning home)
-  // Note: We use GhostState.EATEN or EYES interchangeably depending on how you set it, 
-  // but standardizing on EATEN for the "return trip" is fine.
   if (ghost.state === GhostState.EATEN || ghost.state === GhostState.EYES) {
     const home = { x: ghost.startX, z: ghost.startZ }; 
     if (Math.abs(currentPos.x - home.x) <= 0.5 && Math.abs(currentPos.z - home.z) <= 0.5) {
-       // Arrived home
        return { nextPos: currentPos, nextDir: { x: 0, z: 0 } };
     }
-    const nextStep = getNextStepBFS(currentPos, home, layout);
-    const dirX = nextStep.x - currentPos.x;
-    const dirZ = nextStep.z - currentPos.z;
-    return { nextPos: nextStep, nextDir: { x: dirX, z: dirZ } };
+    return getNextStepBFS(currentPos, home, layout);
   }
 
   // HOUSE LOGIC


### PR DESCRIPTION
Move procedural geometry and material creation out of component render paths (removing many useMemo hooks) for several 3D food components to module scope to improve performance and reduce allocations. Changes include: Cherry, Kebab, Khachapuri, Khinkali, Life, Mchadi, Strawberry — precomputed geometries/materials, seeds/attributes, and texture/color baking applied eagerly. Wrap active bonus Food3D in Suspense in Board3D and preload audio assets in Food3D. Ghost movement now snaps if very far before lerping to avoid large interpolations in Ghost3D. BFS pathfinder in ghostLogic now returns both nextPos and nextDir, handles tunnel X-wrapping, and uses wall-check helper for passability. General cleanup and small API/structure adjustments across the affected files to centralize geometry creation and improve runtime stability.