### PR TITLE
Add ghost flashing visuals and audio tweaks

### DIFF
--- a/src/components/Game/2D/Board.tsx
+++ b/src/components/Game/2D/Board.tsx
@@ -29,6 +29,13 @@ export const Board = ({ isMinimap = false, heading, parentWidth = 0, parentHeigh
 
   const [localPlayerPos, setLocalPlayerPos] = useState({ x: 1, z: 1 });
   const [localGhostsPos, setLocalGhostsPos] = useState<Ghost[]>([]);
+  
+  const [flashTick, setFlashTick] = useState(false);
+
+  useEffect(() => {
+    const interval = setInterval(() => setFlashTick(prev => !prev), 200);
+    return () => clearInterval(interval);
+  }, []);
 
   useEffect(() => {
     setLocalPlayerPos({ ...playerPosRef.current });
@@ -40,7 +47,7 @@ export const Board = ({ isMinimap = false, heading, parentWidth = 0, parentHeigh
     });
   }, [subscribeToPositions, playerPosRef, ghostsPosRef]);
 
- useEffect(() => {
+  useEffect(() => {
     if (!isMinimap) return;
 
     const handleResize = debounce(() => {
@@ -104,7 +111,6 @@ export const Board = ({ isMinimap = false, heading, parentWidth = 0, parentHeigh
 
             const isPower = tile === TileType.POWER_PELLET;
             const isFood = tile === TileType.FOOD;
-
             const isBonusHere = activeBonus && activeBonus.x === colIndex && activeBonus.z === rowIndex;
             
             const scale = isMinimap ? 0.5 : (isMobile ? 0.9 : 1); 
@@ -128,10 +134,8 @@ export const Board = ({ isMinimap = false, heading, parentWidth = 0, parentHeigh
               >
                 {!isPlayerHere && !isGhostHere && (
                     <>
-                        {isPower ? <Food2D type="power" size={foodSize} /> :
-                         isFood ? <Food2D type="dot" size={foodSize} /> : null
-                        }
-                        
+                        {isPower && <Food2D type="power" size={foodSize} />}
+                        {isFood && <Food2D type="dot" size={foodSize} />}
                         {isBonusHere && activeBonus.type === 'CHERRY' && <Food2D type="cherry" size={foodSize} />}
                         {isBonusHere && activeBonus.type === 'STRAWBERRY' && <Food2D type="strawberry" size={foodSize} />}
                         {isBonusHere && activeBonus.type === 'EXTRA_LIFE' && <Food2D type="life" size={foodSize} />}
@@ -145,12 +149,10 @@ export const Board = ({ isMinimap = false, heading, parentWidth = 0, parentHeigh
                 )}
 
                 {isGhostHere && ghost && (() => {
-                    const ghostColor = ghost.state === GhostState.SCARED 
-                        ? '#0000FF' 
-                        : GHOST_COLORS[ghostIndex % GHOST_COLORS.length];
+                    const isFlashing = ghost.state === GhostState.FLASHING;
+                    const isScaredState = ghost.state === GhostState.SCARED || isFlashing;
                     
                     let currentVariant = 1; 
-                    
                     if (ghost.state === GhostState.EATEN) {
                         currentVariant = 3; 
                     } else if (settings.gameTheme === 'labadze') {
@@ -162,16 +164,23 @@ export const Board = ({ isMinimap = false, heading, parentWidth = 0, parentHeigh
                             : 1;
                     }
 
+                    const isLabadzeGhost = currentVariant >= 4 && currentVariant <= 7;
+
+                    const ghostColor = isFlashing 
+                        ? (flashTick ? '#FFFFFF' : '#0000FF')
+                        : (isScaredState ? '#0000FF' : GHOST_COLORS[ghostIndex % GHOST_COLORS.length]);
+
                     return (
                         <div className={cn(
                             "z-30 absolute inset-0 flex items-center justify-center pointer-events-none",
-                            ghost.state !== GhostState.EATEN && "animate-bounce drop-shadow-md"
+                            ghost.state !== GhostState.EATEN && "animate-bounce drop-shadow-md",
+                            isFlashing && isLabadzeGhost && "ghost-css-flash" 
                         )}>
                             <Ghost2D 
                                 variant={currentVariant} 
                                 color={ghostColor} 
                                 size={isMinimap ? cellSize : cellSize * 0.9} 
-                                isScared={ghost.state === GhostState.SCARED} 
+                                isScared={isScaredState} 
                             />
                         </div>
                     );

--- a/src/components/Game/3D/Ghost3D.tsx
+++ b/src/components/Game/3D/Ghost3D.tsx
@@ -44,7 +44,6 @@ export const Ghost3D = ({ index, color }: Ghost3DProps) => {
   const masterMuted = settings.audio.masterMuted;
   const sfxVolume = settings.audio.sfxVolume;
   const isSfxEnabled = !masterMuted && sfxVolume > 0;
-  
   const shouldPlaySound = isSfxEnabled && gameStatus === 'playing';
   const isLabadzeGhost = settings.gameTheme === 'labadze' || settings.ghostVariant >= 4;
   const sirenUrl = isLabadzeGhost ? '/sounds/kacebi/labadze_siren.mp3' : '/sounds/siren.mp3';
@@ -59,73 +58,51 @@ export const Ghost3D = ({ index, color }: Ghost3DProps) => {
 
   useEffect(() => {
     if (audioRef.current) {
-        if (!isSfxEnabled) {
-            audioRef.current.setVolume(0);
-        }
-        if (audioRef.current.setRolloffFactor) {
-            audioRef.current.setRolloffFactor(0); 
-        }
+        if (!isSfxEnabled) audioRef.current.setVolume(0);
+        if (audioRef.current.setRolloffFactor) audioRef.current.setRolloffFactor(0); 
     }
   }, [sfxVolume, isSfxEnabled]);
 
   useEffect(() => {
     if (audioRef.current) {
-      if (gameStatus === 'playing' && !audioRef.current.isPlaying) {
-         audioRef.current.play();
-      } else if (gameStatus !== 'playing' && audioRef.current.isPlaying) {
-         audioRef.current.pause();
-      }
+      if (gameStatus === 'playing' && !audioRef.current.isPlaying) audioRef.current.play();
+      else if (gameStatus !== 'playing' && audioRef.current.isPlaying) audioRef.current.pause();
     }
   }, [gameStatus]);
 
   useFrame((stateThree, delta) => {
     if (!groupRef.current) return;
-    
     const ghost = ghostsPosRef.current[index];
     const playerPos = playerPosRef.current;
-
     if (!ghost || !playerPos) return;
 
-    if (ghost.state !== visualState) {
-        setVisualState(ghost.state);
-    }
+    if (ghost.state !== visualState) setVisualState(ghost.state);
 
-    // აუდიოს ლოგიკა (დისტანციაზე დამოკიდებული ხმა)
     if (audioRef.current) {
         if (!shouldPlaySound) {
             if (audioRef.current.getVolume() > 0) audioRef.current.setVolume(0);
         } else {
             const distance = Math.hypot(ghost.x - playerPos.x, ghost.z - playerPos.z);
             const MAX_AUDIBLE_DISTANCE = 12; 
-            
             if (distance > MAX_AUDIBLE_DISTANCE) {
                 audioRef.current.setVolume(0);
             } else {
                 let volume = 1 - (distance / MAX_AUDIBLE_DISTANCE);
-                if (isWallBetween(playerPos.x, playerPos.z, ghost.x, ghost.z, layout)) {
-                    volume *= 0.2;
-                }
+                if (isWallBetween(playerPos.x, playerPos.z, ghost.x, ghost.z, layout)) volume *= 0.2;
                 audioRef.current.setVolume(volume * sfxVolume * 0.5);
             }
         }
     }
 
-    // პოზიციის lerp 
     const currentPos = groupRef.current.position;
     const targetPos = new Vector3(ghost.x, 0.5, ghost.z);
     const speed = visualState === 'EATEN' ? 15.0 : 6.0; 
-    if (currentPos.distanceTo(targetPos) > 2) {
-       currentPos.copy(targetPos);
-    } else {
-       currentPos.lerp(targetPos, speed * delta);
-    }
+    if (currentPos.distanceTo(targetPos) > 2) currentPos.copy(targetPos);
+    else currentPos.lerp(targetPos, speed * delta);
     
-    // როტაციის გამოთვლა
     const dx = targetPos.x - currentPos.x;
     const dz = targetPos.z - currentPos.z;
-    if (Math.abs(dx) > 0.01 || Math.abs(dz) > 0.01) {
-      targetRotation.current = Math.atan2(dx, dz);
-    }
+    if (Math.abs(dx) > 0.01 || Math.abs(dz) > 0.01) targetRotation.current = Math.atan2(dx, dz);
 
     const tRotation = targetRotation.current;
     const cRotation = groupRef.current.rotation.y;
@@ -135,11 +112,9 @@ export const Ghost3D = ({ index, color }: Ghost3DProps) => {
     const rotationSpeed = visualState === 'EATEN' ? 20.0 : 10.0;
     groupRef.current.rotation.y += diff * rotationSpeed * delta; 
     
-    //  Y ღერძის ბაუნსი ანიმაციისთვის
     if (visualState !== 'EATEN') {
-        if (isLabadzeGhost) {
-            groupRef.current.position.y = 0.5; 
-        } else {
+        if (isLabadzeGhost) groupRef.current.position.y = 0.5; 
+        else {
             const t = stateThree.clock.getElapsedTime();
             groupRef.current.position.y = 0.5 + Math.sin(t * 3) * 0.05;
         }
@@ -148,8 +123,8 @@ export const Ghost3D = ({ index, color }: Ghost3DProps) => {
     }
   });
   
-
-  const displayColor = visualState === 'SCARED' ? '#0000FF' : color;
+  const isFlashing = visualState === 'FLASHING';
+  const displayColor = (visualState === 'SCARED' || visualState === 'FLASHING') ? '#0000FF' : color;
 
   const renderLabadzeGhost = () => {
     const ghostMap: Record<string, LabadzeGhostName> = {
@@ -159,7 +134,6 @@ export const Ghost3D = ({ index, color }: Ghost3DProps) => {
       '#FFB852': 'jafara',
     };
     const ghostName = ghostMap[color] || 'kakaba';
-    
     return <LabadzeGhostModel name={ghostName} ghostState={visualState} />;
   };
 
@@ -177,9 +151,7 @@ export const Ghost3D = ({ index, color }: Ghost3DProps) => {
 
   return (
     <group ref={groupRef} position={[initialPos.x, 0.5, initialPos.z]}>
-      
       <group scale={getScale()} position={[0, getYPosition(), 0]}> 
-        
         {isLabadzeGhost ? (
              renderLabadzeGhost()
         ) : (
@@ -187,22 +159,16 @@ export const Ghost3D = ({ index, color }: Ghost3DProps) => {
                  <Eyes3D /> 
              ) : (
                  <>
-                    {settings.ghostVariant === 1 && <ClassicGhost color={displayColor} />}
-                    {settings.ghostVariant === 2 && <ReaperGhost color={displayColor} />}
+                    {settings.ghostVariant === 1 && <ClassicGhost color={displayColor} isFlashing={isFlashing} />}
+                    {settings.ghostVariant === 2 && <ReaperGhost color={displayColor} isFlashing={isFlashing} />}
                     {settings.ghostVariant === 3 && <Eyes3D />}
                  </>
              )
         )}
-
       </group>
       
       {visualState !== 'EATEN' && visualState !== 'EYES' && (
-        <PositionalAudio
-          ref={audioRef}
-          url={sirenUrl} 
-          distance={1} 
-          loop
-        />
+        <PositionalAudio ref={audioRef} url={sirenUrl} distance={1} loop />
       )}
     </group>
   );

--- a/src/components/Game/3D/Ghosts/ClassicGhost.tsx
+++ b/src/components/Game/3D/Ghosts/ClassicGhost.tsx
@@ -1,45 +1,52 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { Group } from 'three';
+import { Group, MeshStandardMaterial, PointLight } from 'three';
 
 interface GhostProps {
   color: string;
+  isFlashing?: boolean;
 }
 
-export const ClassicGhost = ({ color }: GhostProps) => {
+export const ClassicGhost = ({ color, isFlashing = false }: GhostProps) => {
   const groupRef = useRef<Group>(null);
+  const lightRef = useRef<PointLight>(null);
   
+  const [mat] = useState(() => new MeshStandardMaterial({
+    roughness: 0.3,
+    metalness: 0.1,
+    emissiveIntensity: 0.2
+  }));
+
   useFrame((state) => {
     if(!groupRef.current) return;
     const t = state.clock.getElapsedTime();
     groupRef.current.position.y = Math.sin(t * 1.5) * 0.1;
-  });
 
-  const materialProps = {
-    color: color,
-    emissive: color,
-    emissiveIntensity: 0.2,
-    roughness: 0.3,
-    metalness: 0.1,
-  };
+    if (isFlashing) {
+      const isWhite = Math.floor(t * 5) % 2 === 0; 
+      const flashCol = isWhite ? '#FFFFFF' : '#0000FF';
+      mat.color.set(flashCol);
+      mat.emissive.set(flashCol);
+      if (lightRef.current) lightRef.current.color.set(flashCol);
+    } else {
+      mat.color.set(color);
+      mat.emissive.set(color);
+      if (lightRef.current) lightRef.current.color.set(color);
+    }
+  });
 
   return (
     <group ref={groupRef}>
-      {/* --- თავი --- */}
-      <mesh position={[0, 0.5, 0]}>
+      <mesh position={[0, 0.5, 0]} material={mat}>
         <sphereGeometry args={[0.35, 32, 32]} />
-        <meshStandardMaterial {...materialProps} />
       </mesh>
 
-      {/* --- ტანი --- */}
-      <mesh position={[0, 0, 0]}>
+      <mesh position={[0, 0, 0]} material={mat}>
         <cylinderGeometry args={[0.34, 0.6, 1.1, 32, 1, true]} /> 
-        <meshStandardMaterial {...materialProps} side={2} />
       </mesh>
 
-      {/* --- სახე (საშიში) --- */}
+      {/* სახე*/}
       <group position={[0, 0.45, 0.32]}>
-        {/* თვალები */}
         <group position={[0, 0.1, 0]}>
             <mesh position={[-0.14, 0, 0]} rotation={[0, -0.2, -0.2]}> 
                 <capsuleGeometry args={[0.05, 0.12]} /> 
@@ -50,8 +57,6 @@ export const ClassicGhost = ({ color }: GhostProps) => {
                 <meshBasicMaterial color="black" />
             </mesh>
         </group>
-        
-        {/* პირი */}
         <group position={[0, -0.15, 0.02]}>
             <mesh>
                 <capsuleGeometry args={[0.08, 0.15]} /> 
@@ -61,16 +66,15 @@ export const ClassicGhost = ({ color }: GhostProps) => {
       </group>
       
       {/* --- ხელები --- */}
-      <mesh position={[-0.4, 0.2, 0]} rotation={[0, 0, 0.6]}>
+      <mesh position={[-0.4, 0.2, 0]} rotation={[0, 0, 0.6]} material={mat}>
         <capsuleGeometry args={[0.08, 0.25]} />
-        <meshStandardMaterial {...materialProps} />
       </mesh>
-      <mesh position={[0.4, 0.2, 0]} rotation={[0, 0, -0.6]}>
+      <mesh position={[0.4, 0.2, 0]} rotation={[0, 0, -0.6]} material={mat}>
         <capsuleGeometry args={[0.08, 0.25]} />
-        <meshStandardMaterial {...materialProps} />
       </mesh>
 
-      <pointLight color={color} distance={4} intensity={2} />
+      {/*  განათება */}
+      <pointLight ref={lightRef} distance={4} intensity={2} />
     </group>
   );
 };

--- a/src/components/Game/3D/Ghosts/ReaperGhost.tsx
+++ b/src/components/Game/3D/Ghosts/ReaperGhost.tsx
@@ -1,30 +1,31 @@
-import { useRef, useMemo } from 'react';
+import { useRef, useMemo, useState } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { Group, Shape } from 'three';
+import { Group, Shape, MeshBasicMaterial, PointLight } from 'three';
 
 interface GhostProps {
   color: string;
+  isFlashing?: boolean;
 }
 
-export const ReaperGhost = ({ color }: GhostProps) => {
+export const ReaperGhost = ({ color, isFlashing = false }: GhostProps) => {
   const groupRef = useRef<Group>(null);
   const scytheRef = useRef<Group>(null);
-  
-  // დანის ახალი, სწორი გეომეტრია (აღარ სჭირდება ამოტრიალება)
+
+  const [eyeMat] = useState(() => new MeshBasicMaterial({ toneMapped: false }));
+  const lightRef1 = useRef<PointLight>(null);
+  const lightRef2 = useRef<PointLight>(null);
+
   const { bladeShape, extrudeSettings } = useMemo(() => {
     const shape = new Shape();
-    // დანის ქუსლი (ზუსტად ერგება ხის ტარს)
     shape.moveTo(-0.03, 0.06);
     shape.lineTo(-0.03, -0.06);
-    // შიდა, ბასრი მხარე (მიდის წვერისკენ და ქვემოთ)
     shape.quadraticCurveTo(0.5, -0.05, 1.1, -0.5);
-    // გარე, ყუა (ბრუნდება უკან ტარისკენ)
     shape.quadraticCurveTo(0.5, 0.15, -0.03, 0.06);
     
     return {
       bladeShape: shape,
       extrudeSettings: {
-        depth: 0.01,         // დანის სისქე (ძალიან თხელი და ბასრი)
+        depth: 0.01,         
         bevelEnabled: true,  
         bevelSegments: 2,
         steps: 1,
@@ -40,88 +41,81 @@ export const ReaperGhost = ({ color }: GhostProps) => {
     groupRef.current.position.y = Math.sin(t) * 0.08;
     
     if (scytheRef.current) {
-        // ცელის მსუბუქი რხევა მოჩვენების ხელში
         scytheRef.current.rotation.z = -0.15 + Math.sin(t * 1.5) * 0.05;
         scytheRef.current.rotation.x = 0.1 + Math.sin(t * 1) * 0.05;
+    }
+    if (isFlashing) {
+      const isWhite = Math.floor(t * 5) % 2 === 0;
+      const flashCol = isWhite ? '#FFFFFF' : '#0000FF';
+      eyeMat.color.set(flashCol);
+      if (lightRef1.current) lightRef1.current.color.set(flashCol);
+      if (lightRef2.current) lightRef2.current.color.set(flashCol);
+    } else {
+      eyeMat.color.set(color);
+      if (lightRef1.current) lightRef1.current.color.set(color);
+      if (lightRef2.current) lightRef2.current.color.set(color);
     }
   });
 
   return (
     <group ref={groupRef}>
-      {/* --- მანტია --- */}
+      {/* --- მანტია და კაპიუშონი  */}
       <mesh position={[0, -0.2, 0]}>
         <cylinderGeometry args={[0.1, 0.55, 1.3, 32, 1, true]} />
         <meshStandardMaterial color="#050505" side={2} roughness={1} /> 
       </mesh>
       
-      {/* --- კაპიუშონი --- */}
       <mesh position={[0, 0.4, 0]} rotation={[0.2, 0, 0]}>
         <dodecahedronGeometry args={[0.42, 2]} />
         <meshStandardMaterial color="#050505" roughness={1} side={2} />
       </mesh>
 
-      {/* --- სიბნელე კაპიუშონში --- */}
       <mesh position={[0, 0.45, 0.15]} scale={[0.8, 0.8, 0.8]}>
          <sphereGeometry args={[0.35]} />
          <meshBasicMaterial color="black" /> 
       </mesh>
 
-      {/* --- თვალები --- */}
+      {/* --- თვალები */}
       <group position={[0, 0.5, 0.4]}>
-         <mesh position={[-0.12, 0, 0]} rotation={[0, 0, -0.1]}> 
+         <mesh position={[-0.12, 0, 0]} rotation={[0, 0, -0.1]} material={eyeMat}> 
              <capsuleGeometry args={[0.04, 0.12]} />
-             <meshBasicMaterial color={color} toneMapped={false} />
-             <pointLight distance={0.6} intensity={2} color={color} />
+             <pointLight ref={lightRef1} distance={0.6} intensity={2} />
          </mesh>
-         <mesh position={[0.12, 0, 0]} rotation={[0, 0, 0.1]}>
+         <mesh position={[0.12, 0, 0]} rotation={[0, 0, 0.1]} material={eyeMat}>
              <capsuleGeometry args={[0.04, 0.12]} />
-             <meshBasicMaterial color={color} toneMapped={false} />
-             <pointLight distance={0.6} intensity={2} color={color} />
+             <pointLight ref={lightRef2} distance={0.6} intensity={2} />
          </mesh>
       </group>
 
-      {/* --- ხელები --- */}
+      {/* ხელები და ცელი */}
       <mesh position={[0.35, 0.1, 0.2]}>
           <sphereGeometry args={[0.1]} />
           <meshStandardMaterial color="#050505" />
       </mesh>
 
-      {/* --- ცელი (სრულყოფილად აწყობილი) --- */}
       <group ref={scytheRef} position={[0.35, 0.1, 0.2]} rotation={[0, 0, -0.15]}>
-         
-         {/* 1. მთავარი ხის ტარი */}
          <mesh position={[0, 0.2, 0]}>
             <cylinderGeometry args={[0.02, 0.03, 2.2]} />
             <meshStandardMaterial color="#3b2415" roughness={0.9} />
          </mesh>
-
-         {/* 2. პატარა ხის სახელური შუაში (Snath Peg) */}
          <mesh position={[0.03, -0.2, 0]} rotation={[0, 0, Math.PI / 2]}>
             <cylinderGeometry args={[0.015, 0.012, 0.15]} />
             <meshStandardMaterial color="#3b2415" roughness={0.9} />
          </mesh>
-         
-         {/* 3. ტყავის შემოხვევა დანის ყელთან */}
          <mesh position={[0, 1.1, 0]}>
             <cylinderGeometry args={[0.023, 0.023, 0.2]} />
             <meshStandardMaterial color="#2c1a10" roughness={1} />
          </mesh>
-         
-         {/* 4. მეტალის დამჭერი რგოლი სულ თავში */}
          <mesh position={[0, 1.2, 0]}>
             <cylinderGeometry args={[0.025, 0.025, 0.05]} />
             <meshStandardMaterial color="#1a1a1a" metalness={0.8} roughness={0.5} />
          </mesh>
-
-         {/* 5. ჟანგიანი დანა (ზუსტად ტყავის და რგოლის გასწვრივ გამოდის) */}
          <group position={[0, 1.15, 0]}>
-            {/* -0.005 Z ღერძზე აცენტრებს დანას ტარის მიმართ */}
             <mesh position={[0, 0, -0.005]}>
                 <extrudeGeometry args={[bladeShape, extrudeSettings]} />
                 <meshStandardMaterial color="#616161" metalness={0.7} roughness={0.65} />
             </mesh>
          </group>
-
       </group>
     </group>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -61,3 +61,16 @@ html, body, #root {
   animation: floatUpAndFade 0.8s ease-out forwards;
   pointer-events: none;
 }
+
+@keyframes invertFlash {
+  0%, 100% { 
+    filter: none; 
+  }
+  50% { 
+    filter: brightness(0) invert(1); 
+  }
+}
+
+.ghost-css-flash {
+  animation: invertFlash 0.4s infinite;
+}


### PR DESCRIPTION
Implement flashing/flash-tick visuals for ghosts and tidy up 3D audio/mesh logic.

- 2D Board: add flashTick interval state, simplify food rendering, compute isFlashing/isScaredState and adjust ghost color/variants; add ghost-css-flash class when appropriate and pass scared state to Ghost2D.
- 3D Ghost3D: compute isFlashing, use displayColor accordingly, pass isFlashing to Classic/Reaper variants, simplify audio play/pause and volume/rolloff handling, and minor refactors to position/rotation lerp and bounce logic.
- ClassicGhost & ReaperGhost: accept isFlashing prop, drive material and point-light colors to alternate between white/blue when flashing, and consolidate material creation for smoother updates.
- CSS: add invertFlash keyframes and .ghost-css-flash to support the 2D invert-flash effect.

Overall this change implements the Labadze-style flashing ghost effect across 2D and 3D, updates materials/lights to support flashing, and cleans up audio and rendering logic for more consistent behavior.