### PR TITLE
Use Howler audio context instead of THREE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@eslint/js": "^9.39.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@types/howler": "^2.2.12",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
@@ -3523,6 +3524,13 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/howler": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/@types/howler/-/howler-2.2.12.tgz",
+      "integrity": "sha512-hy769UICzOSdK0Kn1FBk4gN+lswcj1EKRkmiDtMkUGvFfYJzgaDXmVXkSShS2m89ERAatGIPnTUlp2HhfkVo5g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@eslint/js": "^9.39.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@types/howler": "^2.2.12",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",

--- a/src/context/GameProvider.tsx
+++ b/src/context/GameProvider.tsx
@@ -6,7 +6,7 @@ import { calculateGhostNextMove } from '../utils/ghostLogic';
 import { useTheme } from './ThemeContext';
 import { useGameAudio } from '../hooks/useGameAudio'; 
 import { checkCollision, checkFoodEaten, checkBonusEaten } from '../utils/physics';
-import * as THREE from 'three';
+import { Howler } from 'howler';
 
 const MAX_LIVES = 3;
 
@@ -88,9 +88,8 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
   const layoutRef = useRef(layout);
 
   const resumeAudioContext = () => {
-    const audioCtx = THREE.AudioContext.getContext();
-    if (audioCtx && audioCtx.state === 'suspended') {
-      audioCtx.resume();
+    if (Howler.ctx && Howler.ctx.state === 'suspended') {
+      Howler.ctx.resume();
     }
   };
 


### PR DESCRIPTION
Replace THREE.AudioContext.getContext() usage with Howler.ctx.resume() in GameProvider to resume suspended audio via Howler. Also add @types/howler to package.json as a dev dependency to provide typings for Howler.