### PR TITLE
Restrict red zone check to z === 8

### DIFF
--- a/src/utils/ghostLogic.ts
+++ b/src/utils/ghostLogic.ts
@@ -32,7 +32,7 @@ const isWall = (x: number, z: number, layout: number[][], allowHouse: boolean = 
 
 const isRedZone = (x: number, z: number, dir: Coordinate) => {
   if (dir.z === -1) { 
-    if ((x >= 8 && x <= 10) && (z === 8 || z === 20)) return true;
+    if ((x >= 8 && x <= 10) && z === 8) return true;
   }
   return false;
 };


### PR DESCRIPTION
Fix incorrect red-zone detection in isRedZone: remove the z === 20 case so only tiles with x in [8,10] and z === 8 are considered red when dir.z === -1. This prevents false positive red-zone hits during ghost movement.