### PR TITLE
Reduce ghost tunnel speed to 0.08

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -4,7 +4,7 @@ export const GHOST_SPEEDS = {
   NORMAL: 0.20,       
   SCARED: 0.10,       
   EATEN: 0.60,        
-  TUNNEL: 0.10,       
+  TUNNEL: 0.08,       
   ELROY_1: 0.21,      
   ELROY_2: 0.22       
 };


### PR DESCRIPTION
Lower GHOST_SPEEDS.TUNNEL from 0.10 to 0.08 in src/utils/constants.ts to slow ghosts while traversing tunnels. Small gameplay/balance tweak to adjust movement behavior.