### PR TITLE
Add ghost-eating combo & movement fixes

### DIFF
--- a/src/context/GameProvider.tsx
+++ b/src/context/GameProvider.tsx
@@ -25,6 +25,7 @@ const getStartingCoordinates = (currentMap: number[][]) => {
                 let initialZ = rowIndex;
                 let currentDir = { x: 0, z: 0 };
 
+                // Blinky starts outside the ghost house
                 if (type.color === GHOST_CONFIG.BLINKY.color) {
                     initialX = 9;
                     initialZ = 7;
@@ -83,6 +84,8 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
   const ghostsPosRef = useRef<Ghost[]>(ghostsStart);
   const layoutRef = useRef(layout);
   const collisionProcessedRef = useRef(false);
+  
+  const ghostsEatenBatchRef = useRef<number>(0);
 
   const listenersRef = useRef<Set<() => void>>(new Set());
   const notifyListeners = useCallback(() => {
@@ -161,6 +164,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
     resetWaveTimer();
     setActiveBonus(null); 
     clearBonusTimer();
+    ghostsEatenBatchRef.current = 0;
   }, [notifyListeners, clearBonusTimer, resetWaveTimer]);
 
   const startGame = () => {
@@ -207,6 +211,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
     setWaveIndex(0);
     resetWaveTimer();
     playerDirRef.current = { x: 1, z: 0 };
+    ghostsEatenBatchRef.current = 0;
 
     playIntro(); 
   };
@@ -234,6 +239,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
           setWaveIndex(0);
           resetWaveTimer();
           playerDirRef.current = { x: 1, z: 0 };
+          ghostsEatenBatchRef.current = 0;
           playLevelUp(); 
           
           return nextLevelIndex;
@@ -242,12 +248,15 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
 
   const activatePowerMode = useCallback(() => {
     clearPowerTimers();
+    ghostsEatenBatchRef.current = 0;
     
     ghostsPosRef.current = ghostsPosRef.current.map(g => {
         if (g.state === GhostState.EATEN || g.state === GhostState.EYES) return g;
         return { 
             ...g, 
             state: GhostState.SCARED,
+            x: g.x - g.currentDir.x,
+            z: g.z - g.currentDir.z,
             currentDir: { x: -g.currentDir.x, z: -g.currentDir.z }, 
             movementProgress: 1 - g.movementProgress 
         };
@@ -270,6 +279,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
             return g;
         });
         notifyListeners();
+        ghostsEatenBatchRef.current = 0;
     }, POWER_MODE_DURATION_MS);
   }, [clearPowerTimers, notifyListeners, flashTimerRef, powerModeTimerRef]);
 
@@ -296,7 +306,11 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
     else if (hitGhost.state === GhostState.SCARED || hitGhost.state === GhostState.FLASHING) {
         playEatGhost(); 
         
-        setScore(s => s + 200);
+        const comboMultiplier = Math.pow(2, ghostsEatenBatchRef.current);
+        const points = 200 * comboMultiplier;
+        setScore(s => s + points);
+        
+        ghostsEatenBatchRef.current += 1;
         
         const newGhosts = [...ghostsPosRef.current];
         if (newGhosts[hitGhostIndex]) {

--- a/src/hooks/useGameLoop.ts
+++ b/src/hooks/useGameLoop.ts
@@ -84,7 +84,13 @@ export const useGameLoop = ({
                       waveTimerRef.current = 0;
                       
                       ghostsPosRef.current = ghostsPosRef.current.map(g => {
-                          if (g.state === GhostState.NORMAL) return { ...g, currentDir: { x: -g.currentDir.x, z: -g.currentDir.z } };
+                          if (g.state === GhostState.NORMAL) return { 
+                              ...g, 
+                              x: g.x - g.currentDir.x,
+                              z: g.z - g.currentDir.z,
+                              currentDir: { x: -g.currentDir.x, z: -g.currentDir.z },
+                              movementProgress: 1 - g.movementProgress
+                          };
                           return g;
                       });
                       hasPositionChanged = true;

--- a/src/utils/ghostLogic.ts
+++ b/src/utils/ghostLogic.ts
@@ -37,7 +37,6 @@ const isRedZone = (x: number, z: number, dir: Coordinate) => {
   return false;
 };
 
-// --- BFS PATHFINDING (Used for Eyes returning home) ---
 const getNextStepBFS = (start: Coordinate, target: Coordinate, layout: number[][]): { nextPos: Coordinate, nextDir: Coordinate } => {
   const startX = Math.round(start.x);
   const startZ = Math.round(start.z);
@@ -84,7 +83,6 @@ const getNextStepBFS = (start: Coordinate, target: Coordinate, layout: number[][
   return { nextPos: start, nextDir: { x: 0, z: 0 } };
 };
 
-// --- TARGETING ---
 const getBlinkyTarget = (playerPos: Coordinate) => playerPos;
 const getPinkyTarget = (playerPos: Coordinate, playerDir: Coordinate) => ({
   x: playerPos.x + playerDir.x * 4,
@@ -102,7 +100,6 @@ const getClydeTarget = (ghostPos: Coordinate, playerPos: Coordinate) => {
   return getDistSq(ghostPos, playerPos) > 64 ? playerPos : GHOST_CONFIG.CLYDE.scatterTarget;
 };
 
-// --- MOVEMENT ENGINE ---
 const getBestMove = (current: Coordinate, currentDir: Coordinate, target: Coordinate, layout: number[][], allowReverse: boolean, allowHouse: boolean): { nextPos: Coordinate, nextDir: Coordinate } => {
   let bestMove = current;
   let bestDir = currentDir;
@@ -163,10 +160,18 @@ const getRandomMove = (current: Coordinate, currentDir: Coordinate, layout: numb
         const randomIdx = Math.floor(Math.random() * validMoves.length);
         return { nextPos: validMoves[randomIdx].pos, nextDir: validMoves[randomIdx].dir };
     }
+
+    for (const dir of DIRECTIONS) {
+        const nextX = current.x + dir.x;
+        const nextZ = current.z + dir.z;
+        if (!isWall(nextX, nextZ, layout, false)) {
+            return { nextPos: { x: nextX, z: nextZ }, nextDir: dir };
+        }
+    }
+
     return { nextPos: current, nextDir: currentDir };
 };
 
-// --- MAIN EXPORT ---
 export const calculateGhostNextMove = (
   ghost: Ghost,
   allGhosts: Ghost[],
@@ -181,7 +186,6 @@ export const calculateGhostNextMove = (
 
   const currentPos = { x: Math.round(ghost.x), z: Math.round(ghost.z) };
   
-  // EATEN STATE (Eyes returning home)
   if (ghost.state === GhostState.EATEN || ghost.state === GhostState.EYES) {
     const home = { x: ghost.startX, z: ghost.startZ }; 
     if (Math.abs(currentPos.x - home.x) <= 0.5 && Math.abs(currentPos.z - home.z) <= 0.5) {
@@ -190,12 +194,10 @@ export const calculateGhostNextMove = (
     return getNextStepBFS(currentPos, home, layout);
   }
 
-  // HOUSE LOGIC
   if (isInGhostHouse(currentPos)) {
       if (canLeaveHouse) {
           return getBestMove(currentPos, ghost.currentDir, HOUSE_DOOR, layout, false, true);
       } else {
-          // Bounce up and down waiting
           let nextDir = ghost.currentDir;
           if (nextDir.z === 0) nextDir = { x: 0, z: -1 };
           const targetZ = ghost.z + (nextDir.z * 0.2); 
@@ -203,20 +205,14 @@ export const calculateGhostNextMove = (
              nextDir = { x: 0, z: -nextDir.z };
              return { nextPos: { x: ghost.x, z: ghost.z }, nextDir };  
           }
-
-          return {
-              nextPos: { x: ghost.x, z: targetZ },
-              nextDir
-          };
+          return { nextPos: { x: ghost.x, z: targetZ }, nextDir };
       }
   }
 
-  //  SCARED OR FLASHING (Random Movement)
   if (ghost.state === GhostState.SCARED || ghost.state === GhostState.FLASHING) {
     return getRandomMove(currentPos, ghost.currentDir, layout);
   }
 
-  //  CHASE / SCATTER
   let target = playerPos;
   
   if (globalMode === 'SCATTER' && !isElroy) {


### PR DESCRIPTION
Introduce ghostsEatenBatchRef to track consecutive ghosts eaten and apply exponential scoring (200 * 2^n). Reset the batch counter on game start, level reset, power mode activation, and power timeout. Adjust ghost positions, directions and movementProgress when modes change (power activation and wave resets) to prevent movement glitches. In ghost logic, add a fallback in getRandomMove to pick any non-wall direction to avoid getting stuck and tidy up house/BFS handling. Changes touch GameProvider, useGameLoop and ghostLogic.