### PR TITLE
Remove leftover perf-fix comments from Player component

### DIFF
--- a/src/components/Game/3D/Player.tsx
+++ b/src/components/Game/3D/Player.tsx
@@ -7,7 +7,6 @@ import type { PointerLockControls as PointerLockControlsImpl } from 'three-stdli
 
 export const Player = () => {
   const { camera } = useThree();
-  // 🚀 [PERF FIX]: playerPosRef
   const { playerPosRef, movePlayer, gameStatus } = useGame();
   const controlsRef = useRef<PointerLockControlsImpl>(null);
 
@@ -73,7 +72,6 @@ export const Player = () => {
     <>
       <PointerLockControls ref={controlsRef} />
       
-      {/* 🚀 [PERF FIX]: initial position */}
       <group position={[initialPos.x, 0.5, initialPos.z]}>
         <pointLight 
           position={[0, 0.6, 0]} 


### PR DESCRIPTION
Remove two stray performance-fix comments in src/components/Game/3D/Player.tsx — one before the playerPosRef destructuring and one JSX comment near the initial position group. This is a non-functional cleanup to reduce clutter and improve code readability.